### PR TITLE
Better control over emergency stop, no toggle

### DIFF
--- a/catkin_ws/src/wheels_driver/src/wheels_driver_node.py
+++ b/catkin_ws/src/wheels_driver/src/wheels_driver_node.py
@@ -107,7 +107,7 @@ class WheelsDriverNode(object):
 
 
     def cbEStop(self,msg):
-        self.estop=not self.estop
+        self.estop=msg.data
         if self.estop:
             rospy.loginfo("[%s] Emergency Stop Activated")
         else:


### PR DESCRIPTION
Currently the emergency-stop message works as a toggle and the actual state can not be known, the suggested change would prevent this