### PR TITLE
Add custom RGB interface for controlling leds

### DIFF
--- a/packages/led_emitter/src/led_emitter_node.py
+++ b/packages/led_emitter/src/led_emitter_node.py
@@ -189,9 +189,6 @@ class LEDEmitterNode(DTROS):
             'frequency': req.pattern.frequency
         }
 
-        # If the message contains
-        self.log(f"rgb_bals len: {len(req.pattern.rgb_vals)}")
-        self.log(f"color_list len: {len(req.pattern.color_list)}")
 
         # If there is no data in color_list, we fallback to rgb_vals
         override_color_list = False


### PR DESCRIPTION
I added the functionality to display custom RGB values on the leds.
I tried different methods, but in the ends we really need to keep the string type if we don't want to refactor the whole protocol. As of now, if the color_list contains at least a digit and a coma, it is considered a RGB type (parsed into an array), as opposed to a color string.

HOW TO TEST:

In the duckiebot interface container (or anywhere that has access to the ros namespace), call the service using the command line:

```
rosservice call /ROBOT_NAME/led_emitter_node/set_custom_pattern "pattern:
  header:
    seq: 0
    stamp: {secs: 0, nsecs: 0}
    frame_id: ''
  color_list: ['']
  rgb_vals:
  - {r: 0.0, g: 1.0, b: 0.0, a: 1.0}
  - {r: 1.0, g: 0.0, b: 0.0, a: 1.0}
  - {r: 1.0, g: 0.0, b: 1.0, a: 1.0}
  - {r: 1.0, g: 1.0, b: 0.0, a: 1.0}
  - {r: 0.0, g: 1.0, b: 1.0, a: 1.0}
  color_mask: [1,1,1,1,1]
  frequency: 0.0
  frequency_mask: [1,1,1,1,1]"
```

Note: I also have changes for the fifos bridge and the random template, although I have not done enough testing to publish those. Will do in the following days.

I'd like someone else to test before merging since I am not familiar with the other workflows using leds and I do not have a DB21.








## Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.
- Explicitly mention if the current changes can (or could) break any existing interface or functionality.
- If this pull request results in from a fix to a GitHub issue, give a link to it.

## Type of change

Please mark the relevant options with X:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is constrained only to one package, any interfaces to nodes from other packages are maintained
- [ ] This change is constrained only to packages in this repository, any interfaces to nodes from other repositories are maintained
- [ ] This change required a documentation update
- [ ] This change is only a documentation update
- [ ] This change restructures the repository (at level higher than package level)
- [ ] This change requires a change in the Duckiebook (if yes, please describe and, if possible, make a pull request for an edit in the book and link it here)

## Tests

Please describe all tests ran and their outcome. It is highly recommended that you at least do the tests listed by default, even if you only changed the documentation.

- [ ] Made the Duckiebot move with keyboard control
- [ ] Visually checked the published camera stream
- [ ] Verified that the lane following demo works
- [ ] Verified that the indefinite navigation demo works

## Style compliance
Please make sure that all your changes conform to the Duckietown (code style)[link] and code (documentation style)[link] guidelines:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I checked that this pull request is compliant with the Duckietown code style
- [ ] I checked that this pull request is compliant with the Duckietown code documentation style

## Next steps
Please describe if you have any questions, comments, or doubts towards the Duckietown software guardians regarding implementation, code style, running tests, documentation, etc.

## FOR THE REVIEWERS
__IMPORTANT:__ DO NOT CHANGE THIS SECTION!

- [ ] Functionality (is the change necessary and is it implemented in the most appropriate way): @liampaull or @afdaniele
- [ ] Integration testing (verify the tests and run additional if necessary): @?
- [ ] Code style compliance: @gibernas
- [ ] Documentation compliance: @aleksandarpetrov

_To the reviewers:_ If you deem necessary, request code edits, more tests, documentation update, or additional reviewing. __Do not review your own code!__

_PR Template, last edit 23 Aug 2019_
