### PR TITLE
Show shutdown behaviors with dts/Dashboard shutdown

### DIFF
--- a/packages/button_driver/src/button_driver_node.py
+++ b/packages/button_driver/src/button_driver_node.py
@@ -16,8 +16,9 @@ from hardware_test_button import HardwareTestButton
 from dt_device_utils.device import shutdown_device
 
 # for shutting down the front and back LEDs
-from duckietown_msgs.srv import ChangePattern
-from std_msgs.msg import String
+from duckietown_msgs.msg import LEDPattern
+from std_msgs.msg import ColorRGBA
+from std_srvs.srv import Trigger, TriggerResponse
 from duckietown.dtros.utils import apply_namespace
 
 # display renderer for shutdown confirmation
@@ -48,14 +49,11 @@ class ButtonDriverNode(DTROS):
         # create button driver
         self._button = ButtonDriver(self._led_gpio_pin, self._signal_gpio_pin, self._event_cb)
         self._button.led.on()
-        # display to confirm shutdown
-        self._renderer = BatteryShutdownConfirmationRenderer()
-        self._display_pub = rospy.Publisher(
-            "~fragments",
-            DisplayFragment,
-            queue_size=1,
-            dt_topic_type=TopicType.VISUALIZATION,
-            dt_help="Fragments to display on the display",
+
+        # shutdown confirmation service (for external methods of shutting down, e.g. dts/Dashboard):
+        #   turn off LED, blink power LED, show Shutdown page on Display
+        self._srv_shutdown_behavior = rospy.Service(
+            "~shutdown_behavior", Trigger, self._srv_cb_shutdown_behavior,
         )
         # create event holder
         self._ongoing_event = None
@@ -85,8 +83,6 @@ class ButtonDriverNode(DTROS):
             return
         # - held for 3 secs
         if self._TIME_HOLD_3S < duration < 2 * self._TIME_HOLD_3S:
-            # publish a display showing shutdown confirmation
-            self._display_pub.publish(self._renderer.as_msg())
             time.sleep(1)
             self._publish(ButtonEventMsg.EVENT_HELD_3SEC)
             self._react(ButtonEventMsg.EVENT_HELD_3SEC)
@@ -102,28 +98,57 @@ class ButtonDriverNode(DTROS):
 
     def _react(self, event: int):
         if event in [ButtonEventMsg.EVENT_HELD_3SEC, ButtonEventMsg.EVENT_HELD_10SEC]:
-            # blink top power button as a confirmation, too
-            self._button.led.confirm_shutdown()
-
-            # turn off front and back LEDs
-            try:
-                srv = rospy.ServiceProxy(
-                    apply_namespace("led_emitter_node/set_pattern", ns_level=1),
-                    ChangePattern,
-                )
-                msg = String()
-                msg.data = "LIGHT_OFF"
-                resp = srv(msg)
-                self.loginfo(str(resp))
-            except rospy.ServiceException as e:
-                # not a big deal if failed this
-                self.logerr("LED shutdown service call failed {}".format(e))
-
-            time.sleep(1)
+            self._show_shutdown_behavior()
             # init shutdown sequence
             res = shutdown_device()
             if not res:
                 self.logerr("Could not initialize the shutdown sequence")
+    
+    def _show_shutdown_behavior(self):
+        # the page confirming shutdown
+        _renderer = BatteryShutdownConfirmationRenderer()
+        # publish a display showing shutdown confirmation
+        _display_pub = rospy.Publisher(
+            "~fragments",
+            DisplayFragment,
+            latch=True,
+            queue_size=1,
+        )
+        _display_pub.publish(_renderer.as_msg())
+        n_times_to_try = 3
+        # try several times to go to page
+        for _ in range(n_times_to_try):
+            # emulate button event to switch to shutdown page
+            self._publish(ButtonEventMsg.EVENT_HELD_3SEC)
+            rospy.sleep(1.0 / n_times_to_try)
+
+        # turn off LEDs
+        _led_pub = rospy.Publisher(
+            apply_namespace("led_emitter_node/led_pattern", ns_level=1),
+            LEDPattern,
+            latch=True,
+            queue_size=1,
+        )
+        msg_led = LEDPattern()
+        msg_rgba = ColorRGBA(r=0, g=0, b=0, a=0)
+        msg_led.rgb_vals = [msg_rgba] * 5
+        _led_pub.publish(msg_led)
+
+        # blink top power button as a confirmation, too
+        self._button.led.confirm_shutdown()
+
+        rospy.sleep(1)
+
+    def _srv_cb_shutdown_behavior(self, _):
+        # for external methods of shutting down (e.g. from dts or the Dashboard)
+        try:
+            self._show_shutdown_behavior()
+            return TriggerResponse(success=True, message="")
+        except Exception as e:
+            return TriggerResponse(
+                success=False,
+                message=f"Failed to show shutdown behaviors. Reason: {e}",
+            )
 
     def on_shutdown(self):
         if hasattr(self, "_button"):

--- a/packages/button_driver/src/button_driver_node.py
+++ b/packages/button_driver/src/button_driver_node.py
@@ -98,9 +98,11 @@ class ButtonDriverNode(DTROS):
 
     def _react(self, event: int):
         if event in [ButtonEventMsg.EVENT_HELD_3SEC, ButtonEventMsg.EVENT_HELD_10SEC]:
-            self._show_shutdown_behavior()
             # init shutdown sequence
             res = shutdown_device()
+            # NOTE: the above method initiates the shutdown process with health-API,
+            # which eventually calls the _show_shutdown_behavior function via a service
+
             if not res:
                 self.logerr("Could not initialize the shutdown sequence")
     

--- a/packages/robot_http_api/include/dt_robot_rest_api/actions/shutdown_behavior/__init__.py
+++ b/packages/robot_http_api/include/dt_robot_rest_api/actions/shutdown_behavior/__init__.py
@@ -1,0 +1,25 @@
+import rospy
+import traceback
+from flask import Blueprint
+from std_srvs.srv import Trigger, TriggerRequest, TriggerResponse
+from dt_robot_rest_api.utils import response_ok, response_error
+
+
+shutdown_behavior_bp = Blueprint("shutdown_behavior", __name__)
+
+# this service will be called, when the API is triggered
+_srv_proxy = rospy.ServiceProxy("~shutdown_behavior", Trigger)
+_trigger = TriggerRequest()
+
+
+@shutdown_behavior_bp.route("/shutdown_behavior")
+def _show_shutdown_behavior():
+    try:
+        resp: TriggerResponse = _srv_proxy(_trigger)
+        if resp.success:
+            return response_ok({})
+        else:
+            return response_error(message=resp.message)
+    except Exception as e:
+        traceback.print_exc()
+        return response_error(message=f"Failed to run shutdown behaviors. Reason: {e}")

--- a/packages/robot_http_api/include/dt_robot_rest_api/robot/duckiebot.py
+++ b/packages/robot_http_api/include/dt_robot_rest_api/robot/duckiebot.py
@@ -4,7 +4,8 @@ from dt_robot_utils import RobotType
 from dt_robot_rest_api.actions.estop import estop_bp
 from dt_robot_rest_api.actions.car import car_bp
 from dt_robot_rest_api.actions.logs import logs_bp
+from dt_robot_rest_api.actions.shutdown_behavior import shutdown_behavior_bp
 
 
-blueprints = [estop_bp, car_bp, logs_bp]
+blueprints = [estop_bp, car_bp, logs_bp, shutdown_behavior_bp]
 HTTP_PORT = HTTP_PORTS[RobotType.DUCKIEBOT]

--- a/packages/robot_http_api/launch/robot_http_api_node.launch
+++ b/packages/robot_http_api/launch/robot_http_api_node.launch
@@ -8,6 +8,7 @@
     <group ns="$(arg veh)">
         <remap if="$(eval robot_type == 'duckiebot')" from="robot_http_api_node/estop" to="wheels_driver_node/emergency_stop"/>
         <remap if="$(eval robot_type == 'duckiebot')" from="robot_http_api_node/wheels_cmd" to="wheels_driver_node/wheels_cmd"/>
+        <remap if="$(eval robot_type == 'duckiebot')" from="robot_http_api_node/shutdown_behavior" to="button_driver_node/shutdown_behavior"/>
         <node pkg="robot_http_api" type="$(arg node_name).py" name="$(arg node_name)" output="screen" required="true" />
     </group>
 </launch>


### PR DESCRIPTION
This PR adds an API endpoint for other shutdown methods, e.g. health-API, to make the robot show the shutdown behaviors (power LEDs, LEDs, Display).

The tests performed are recorded in the JIRA task: DTSW-2399