### PR TITLE
Publish imu in a human-friendly frame, add different config DB21J

### DIFF
--- a/packages/duckiebot_interface/urdf/duckiebot.urdf.xacro
+++ b/packages/duckiebot_interface/urdf/duckiebot.urdf.xacro
@@ -526,14 +526,6 @@
                 <origin xyz="0.017 0 0" rpy="-${0.5 * pi} 0 -${0.5 * pi}" />
             </joint>
 
-            <!-- IMU -->
-            <link name="${veh}/imu"/>
-            <joint name="${veh}_bottom_plate_to_imu" type="fixed">
-                <parent link="${veh}/bottom_plate"/>
-                <child link="${veh}/imu"/>
-                <origin xyz="0 0 0" />
-            </joint>
-
             <!-- TOF -->
             <link name="${veh}/tof/front_center"/>
             <joint name="${veh}_front_bumper_to_front_center_tof" type="fixed">
@@ -544,6 +536,26 @@
 
             <!-- END: Duckiebot: DB21X -->
 
+        </xacro:if>
+
+        <xacro:if value="${model in ['DB21M']}" >
+            <!-- IMU on DB21M -->
+            <link name="${veh}/imu"/>
+            <joint name="${veh}_bottom_plate_to_imu" type="fixed">
+                <parent link="${veh}/bottom_plate"/>
+                <child link="${veh}/imu"/>
+                <origin xyz="0 0 0"/>
+            </joint>
+        </xacro:if>
+
+        <xacro:if value="${model in ['DB21J', 'DBR4']}" >
+            <!-- IMU on other DB21X -->
+            <link name="${veh}/imu"/>
+            <joint name="${veh}_bottom_plate_to_imu" type="fixed">
+                <parent link="${veh}/bottom_plate"/>
+                <child link="${veh}/imu"/>
+                <origin xyz="0.024 0 0.019"  rpy="0 ${pi} 0"/>
+            </joint>
         </xacro:if>
 
         <!-- END: Duckiebot -->

--- a/packages/imu_driver/src/imu_node.py
+++ b/packages/imu_driver/src/imu_node.py
@@ -5,8 +5,6 @@ from typing import Optional
 
 import adafruit_mpu6050
 import board
-import copy
-import numpy as np
 import rospy
 import yaml
 from adafruit_mpu6050 import MPU6050

--- a/packages/imu_driver/src/imu_node.py
+++ b/packages/imu_driver/src/imu_node.py
@@ -141,8 +141,7 @@ class IMUNode(DTROS):
                 (acc_data[i] - self._accel_offset[i]) for i in range(len(acc_data)))
             msg.linear_acceleration_covariance = [0.0 for _ in range(len(msg.linear_acceleration_covariance))]
 
-            msg.header.frame_id = self._fallback_pub_frame  # start from sensor frame
-            # perform transfrom and change frame if applicable
+            # perform transfrom if applicable
             if self._imu_pub_frame != self._fallback_pub_frame:
                 ang_vel = [
                     msg.angular_velocity.x,
@@ -167,11 +166,8 @@ class IMUNode(DTROS):
                 msg.linear_acceleration.y = linear_acc[1]
                 msg.linear_acceleration.z = linear_acc[2]
 
-                # set the applied frame
-                msg.header.frame_id = self._imu_pub_frame
-
             # set same frame for temperature message to be consistent 
-            temp_msg.header.frame_id = self._imu_pub_frame
+            msg.header.frame_id = temp_msg.header.frame_id = self._imu_pub_frame
 
             # Pub
             self.pub.publish(msg)


### PR DESCRIPTION
* New URDF config has been added for `DB21J` (when IMU is mounted between the Jetson and the camera)
* The imu node is modified to look for transforms on `f"{robot_hostname}/imu"` as a child. If the `bottom_plate` -> `imu` tf is found, the IMU messages are published in the bottom plate frame, which makes more sense to the user, considering the different mounting positions in DB21M and DB21J.

---

Tested with Dashboard IMU Hardware test, the plane movements correspond to robot movements with DB21J config now. Also, in the messages it can be verified the `frame_id` has been updated.

![image](https://github.com/duckietown/dt-duckiebot-interface/assets/10885835/b0d08c74-cc06-4441-abfd-16e0e133ef60)
