### PR TITLE
Fix: support MPU6050 IMU clones (ICM-2068x) in imu driver

### DIFF
--- a/packages/imu_driver/src/imu_node.py
+++ b/packages/imu_driver/src/imu_node.py
@@ -56,18 +56,53 @@ class IMUNode(DTROS):
         self._hardware_test = HardwareTestIMU()
 
     def _find_sensor(self) -> Optional[MPU6050]:
-        for connector in self._i2c_connectors:
-            conn: str = "[bus:{bus}](0x{address:02X})".format(**connector)
-            self.loginfo(f"Trying to open device on connector {conn}")
-            # Overwrite Adafruit default device ID
-            adafruit_mpu6050._MPU6050_DEVICE_ID = connector["address"]
+        """
+        Probe every (bus, address) pair listed in ~connectors.
+        Accept both genuine MPU-6050 (WHO_AM_I = 0x68) and the newer
+        ICM-2068x clones that return WHO_AM_I = 0x98.
+        """
+        # two IDs we know how to handle
+        ALLOWED_IDS = (0x68, 0x98)          # MPU-6050, ICM-2068x
+
+        for c in self._i2c_connectors:
+            bus_n = c["bus"]
+            addr  = c["address"]
+
+            self.loginfo(f"Trying IMU on I²C-{bus_n} @ 0x{addr:02X}")
+
+            # ---------- read WHO_AM_I first ----------
             try:
-                sensor = MPU6050(board.I2C())
-            except Exception:
-                self.logwarn(f"No devices found on connector {conn}, but the bus exists")
+                import smbus2
+                with smbus2.SMBus(bus_n) as bus:
+                    who = bus.read_byte_data(addr, 0x75)
+            except FileNotFoundError:
+                self.logwarn(f"I²C bus {bus_n} does not exist")
                 continue
-            self.loginfo(f"Device found on connector {conn}")
-            return sensor
+            except OSError as e:
+                self.logwarn(f"No response at 0x{addr:02X} on bus {bus_n}: {e}")
+                continue
+
+            if who not in ALLOWED_IDS:
+                self.logwarn(
+                    f"Unknown IMU (WHO_AM_I 0x{who:02X}) at 0x{addr:02X} on bus {bus_n}"
+                )
+                continue
+
+            # ---------- patch Adafruit driver and instantiate ----------
+            adafruit_mpu6050._MPU6050_DEVICE_ID = who       # make the sanity-check happy
+
+            try:
+                sensor = adafruit_mpu6050.MPU6050(board.I2C(), address=addr)
+                self.loginfo(
+                    f"Found IMU (ID 0x{who:02X}) on I²C-{bus_n} @ 0x{addr:02X}"
+                )
+                return sensor
+            except RuntimeError as e:
+                self.logwarn(f"Driver rejected device at 0x{addr:02X}: {e}")
+                continue
+
+        # nothing worked
+        return None
 
     def publish_data(self, event):
         # Message Blank


### PR DESCRIPTION
### Summary  
`imu_node` currently works only with first-generation MPU-6050 sensors (`WHO_AM_I = 0x68`). New boards use an ICM-2068x clone that returns `0x98`, causing the Adafruit driver to throw and the node to exit. This change adds dual-ID support so both revisions initialise and publish normally.

### Background / Problem  
* New IMU revision returns `WHO_AM_I = 0x98`.  
* Adafruit `MPU6050` driver hard-codes expected ID to `0x68`.  
* Result: node dies at start-up; no `/imu/data`, localisation chain broken.

### Scope of Change  
* Replace `_find_sensor()` with logic that  
  1. Scans each configured `(bus, address)` pair.  
  2. Reads register `0x75` via `smbus2`.  
  3. Accepts IDs in **{0x68, 0x98}**; others are rejected.  
  4. Patches `adafruit_mpu6050._MPU6050_DEVICE_ID` to the detected value.  
  5. Instantiates `MPU6050(board.I2C(), address=addr)` and returns on success.  
* Remove code that overwrote the ID with the bus address.

### Acceptance Criteria  
| WHO_AM_I | Board | Expected node state |  
|----------|-------|---------------------|  
| `0x68` | Genuine MPU-6050 | **STARTED**, publishes IMU & temperature topics |  
| `0x98` | ICM-2068x clone | **STARTED**, publishes identical topics |  
| other | Unknown | Node logs warning, enters **ERROR** state |

### Test Plan  
1. Hardware test on a bot with legacy IMU → topics at 30 Hz.  
1. Hardware test on a bot with new IMU → same behaviour.  