### PR TITLE
DTSW-6883-fix-imu-driver-not-working-with-newer-im-us

### DIFF
--- a/packages/imu_driver/include/imu_driver/mpu6050.py
+++ b/packages/imu_driver/include/imu_driver/mpu6050.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import board
 import adafruit_mpu6050
 from adafruit_mpu6050 import MPU6050
+from smbus2 import SMBus  # NEW
 
 from dtps import DTPSContext
 from .exceptions import DeviceNotFound
@@ -13,6 +14,8 @@ from .types import I2CConnector
 
 
 class CalibratedMPU6050:
+    WHO_AM_I_REG = 0x75
+    ALLOWED_IDS = (0x68, 0x98)        # MPU-6050, ICM-2068x
 
     def __init__(self, i2c_connectors: List[I2CConnector], cxt: DTPSContext, logger: Logger):
         self._i2c_connectors: List[I2CConnector] = i2c_connectors
@@ -55,19 +58,47 @@ class CalibratedMPU6050:
                           "\tGyro X:{:.2f}, Y: {:.2f}, Z: {:.2f} degrees/s"
                           "".format(*self._accelerometer_offsets, *self._gyroscope_offsets))
 
-    def _find_sensor(self) -> Optional[MPU6050]:
+    def _find_sensor(self) -> MPU6050:
+        """
+        Scan each (bus, address) pair in ~connectors.
+        Accept devices whose WHO_AM_I register is 0x68 (MPU-6050)
+        or 0x98 (ICM-2068x clone).  Anything else is ignored.
+        """
         for connector in self._i2c_connectors:
-            conn: str = "[bus:{bus}](0x{address:02X})".format(**dataclasses.asdict(connector))
-            self._logger.info(f"Trying to open device on connector {conn}")
-            # overwrite Adafruit default device ID
-            adafruit_mpu6050._MPU6050_DEVICE_ID = connector.address
-            # noinspection PyBroadException
+            bus_n = connector.bus
+            addr = connector.address
+            conn_str = "[bus:{bus}](0x{address:02X})".format(**dataclasses.asdict(connector))
+            self._logger.info(f"Trying to open device on connector {conn_str}")
+
+            # --- read WHO_AM_I first -----------------------------------
             try:
-                sensor = MPU6050(board.I2C())
-            except Exception:
-                self._logger.warning(f"No devices found on connector {conn}, but the bus exists")
+                with SMBus(bus_n) as bus:
+                    who_am_i = bus.read_byte_data(addr, self.WHO_AM_I_REG)
+            except FileNotFoundError:
+                self._logger.warning(f"I²C bus {bus_n} does not exist")
                 continue
-            self._logger.info(f"Device found on connector {conn}")
+            except OSError:
+                self._logger.warning(f"No devices found on connector {conn_str}, but the bus exists")
+                continue
+
+            if who_am_i not in self.ALLOWED_IDS:
+                self._logger.warning(
+                    f"Unknown IMU WHO_AM_I=0x{who_am_i:02X} on connector {conn_str}, skipping"
+                )
+                continue
+
+            # --- patch driver constant and instantiate -----------------
+            adafruit_mpu6050._MPU6050_DEVICE_ID = who_am_i
+            try:
+                sensor = MPU6050(board.I2C(), address=addr)
+            except Exception as e:
+                self._logger.warning(f"Driver rejected device on {conn_str}: {e}")
+                continue
+
+            self._logger.info(
+                f"Device (WHO_AM_I=0x{who_am_i:02X}) found on connector {conn_str}"
+            )
             return sensor
-        # if no sensor found, raise
+
+        # none of the connectors yielded a valid sensor
         raise DeviceNotFound()


### PR DESCRIPTION
### Summary  
`imu_node` currently works only with first-generation MPU-6050 sensors (`WHO_AM_I = 0x68`). New boards use an ICM-2068x clone that returns `0x98`, causing the Adafruit driver to throw and the node to exit. This change adds dual-ID support so both revisions initialise and publish normally.

### Background / Problem  
* New IMU revision returns `WHO_AM_I = 0x98`.  
* Adafruit `MPU6050` driver hard-codes expected ID to `0x68`.  
* Result: node dies at start-up; no `/imu/data`, localisation chain broken.

### Scope of Change  
* Replace `_find_sensor()` with logic that  
  1. Scans each configured `(bus, address)` pair.  
  2. Reads register `0x75` via `smbus2`.  
  3. Accepts IDs in **{0x68, 0x98}**; others are rejected.  
  4. Patches `adafruit_mpu6050._MPU6050_DEVICE_ID` to the detected value.  
  5. Instantiates `MPU6050(board.I2C(), address=addr)` and returns on success.  
* Remove code that overwrote the ID with the bus address.

### Acceptance Criteria  
| WHO_AM_I | Board | Expected node state |  
|----------|-------|---------------------|  
| `0x68` | Genuine MPU-6050 | **STARTED**, publishes IMU & temperature topics |  
| `0x98` | ICM-2068x clone | **STARTED**, publishes identical topics |  
| other | Unknown | Node logs warning, enters **ERROR** state |

### Test Plan  
1. Hardware test on a bot with legacy IMU → topics at 30 Hz.  
1. Hardware test on a bot with new IMU → same behaviour.  