### PR TITLE
Fix "Test Hardware" buttons on the Components page of the Dashboard

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -12,6 +12,9 @@ luma.oled==3.13.0
 # dependencies for the IMU sensor
 adafruit-circuitpython-mpu6050==1.2.3
 
+# dependencies for the LED hardware test
+colorir==2.0.1
+
 # dependency for the flight controller
 mavsdk==2.8.3
 

--- a/packages/button_driver/include/button_driver/button.py
+++ b/packages/button_driver/include/button_driver/button.py
@@ -46,6 +46,10 @@ class ButtonDriver:
         GPIO.setup(self._signal_gpio_pin, GPIO.IN)
         # create LED object
         self._led = ButtonLED(led_gpio_pin)
+        # prevent_default when performing tests
+        self._prevent_default = False
+        # callback when test finishes, only supplied when starting a test
+        self._test_callback = None
         # attach event listeners to the signal GPIO pin
         GPIO.add_event_detect(self._signal_gpio_pin, GPIO.BOTH, callback=self._cb)
 
@@ -56,7 +60,22 @@ class ButtonDriver:
     def _cb(self, pin):
         signal = int(GPIO.input(pin))
         event = ButtonEvent(signal)
+        # when running tests
+        if self._prevent_default:
+            if event == ButtonEvent.RELEASE:
+                if isinstance(self._test_callback, Callable):
+                    self._test_callback()
+                self.finish_test()
+            return
         self._callback(event)
+
+    def start_test(self, test_cb):
+        self._test_callback = test_cb
+        self._prevent_default = True
+
+    def finish_test(self):
+        self._prevent_default = False
+        self._test_callback = None
 
     def shutdown(self):
         # remove event listeners

--- a/packages/button_driver/include/button_driver_node/main.py
+++ b/packages/button_driver/include/button_driver_node/main.py
@@ -9,6 +9,7 @@ import argparse
 
 from button_driver import ButtonEvent, ButtonDriver
 from dt_device_utils.device import shutdown_device
+from button_hardware_test import ButtonHardwareTest
 
 # from display_renderer import (
 #     PAGE_SHUTDOWN,
@@ -52,7 +53,7 @@ class ButtonDriverNode(Node):
         self.configuration: ButtonDriverNodeConfiguration = (ButtonDriverNodeConfiguration.
                                                              from_name(self.package, node_name, config))
         # queues
-        self._queue: Optional[DTPSContext] = None
+        self._event_queue: Optional[DTPSContext] = None
         # create a ButtonDriver sensor handler
         self._sensor: ButtonDriver = ButtonDriver(
             self.configuration.led_gpio_pin,
@@ -68,7 +69,7 @@ class ButtonDriverNode(Node):
 
     def _event_cb(self, event: ButtonEvent):
         # wait for DTPS to initialize
-        if self._queue is None:
+        if self._event_queue is None:
             return
         # create partial event
         if event == ButtonEvent.PRESS:
@@ -102,7 +103,7 @@ class ButtonDriverNode(Node):
             header=header,
             type=event,
         ).to_rawdata()
-        await self._queue.publish(rdata)
+        await self._event_queue.publish(rdata)
         # return control to the event loop
         await asyncio.sleep(0.01)
         # react
@@ -121,15 +122,23 @@ class ButtonDriverNode(Node):
     async def worker(self):
         await self.dtps_init(self.configuration)
         # create sensor queue
-        self._queue = await (self.context / "out" / "event").queue_create()
+        self._event_queue = await (self.context / "out" / "event").queue_create()
+        test_in_queue = await (self.context / "test" / "in").queue_create()
+        test_out_queue = await (self.context / "test" / "out").queue_create()
+        # test
+        hardware_test = ButtonHardwareTest(self, test_out_queue, self._sensor)
+        # subscriptions
+        await test_in_queue.subscribe(hardware_test.on_run_test)
         # expose node to the switchboard
         await self.dtps_expose()
         # expose queues to the switchboard
-        await (self.switchboard / "sensor" / "power_button" / self.sensor_name / "event").expose(self._queue)
+        await (self.switchboard / "sensor" / "power_button" / self.sensor_name / "event").expose(self._event_queue)
+        await (self.switchboard / "sensor" / "power_button" / self.sensor_name / "test" / "in").expose(test_in_queue)
+        await (self.switchboard / "sensor" / "power_button" / self.sensor_name / "test" / "out").expose(test_out_queue)
         # publish no event
         timestamp = time.time()
         header = Header(timestamp=timestamp)
-        await self._queue.publish(ButtonEventMsg(
+        await self._event_queue.publish(ButtonEventMsg(
             header=header,
             type=InteractionEvent.NOTHING,
         ).to_rawdata())

--- a/packages/button_driver/include/button_hardware_test/__init__.py
+++ b/packages/button_driver/include/button_hardware_test/__init__.py
@@ -1,0 +1,1 @@
+from .button_hardware_test import ButtonHardwareTest

--- a/packages/button_driver/include/button_hardware_test/button_hardware_test.py
+++ b/packages/button_driver/include/button_hardware_test/button_hardware_test.py
@@ -1,0 +1,45 @@
+import time
+from typing import Any
+
+from dt_duckiebot_hardware_tests import AbstractHardwareTest
+from dtps import DTPSContext
+from duckietown_messages.standard.dictionary import Dictionary
+
+from button_driver import ButtonDriver
+
+
+class ButtonHardwareTest(AbstractHardwareTest):
+    _button_released: bool
+    _driver: ButtonDriver
+
+    def __init__(self, node: Any, test_out_queue: DTPSContext, driver: ButtonDriver) -> None:
+        super().__init__(node, test_out_queue)
+        self._driver = driver
+        self._button_released = False
+
+    def _button_event_cb(self) -> None:
+        self._button_released = True
+
+    async def run_test(self, dictionary: Dictionary) -> None:
+        test_id = dictionary.data["test_id"]
+        test_timeout = dictionary.data["test_timeout"]
+        led_blink_secs = dictionary.data["led_blink_secs"]
+        led_blink_hz = dictionary.data["led_blink_hz"]
+        self.message = f"[{test_id}] led_blink_secs = {led_blink_secs}, led_blink_hz = {led_blink_hz}"
+        # button led test
+        self._driver.led.blink(led_blink_secs, led_blink_hz)
+        # button press event test
+        self._driver.start_test(self._button_event_cb)
+        sleep_duration = 0.1
+        counter = 0
+        while not self._button_released:
+            if counter > test_timeout:
+                message = f"[{test_id}] Button not released in time."
+                raise Exception(message)
+            if round(counter, 1) % 1 == 0:
+                self._node.loginfo(f"[{test_id}] Waiting for button to be released... ({round(counter)}/{test_timeout} seconds)")
+            time.sleep(sleep_duration)
+            counter += sleep_duration
+        self._node.loginfo(f"[{test_id}] Button released.")
+        # reset
+        self._button_released = False

--- a/packages/button_driver/setup.py
+++ b/packages/button_driver/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 package_name = 'button_driver'
-packages = ["button_driver", "button_driver_node"]
+packages = ["button_driver", "button_driver_node", "button_hardware_test"]
 
 setup(
     name=package_name,

--- a/packages/display_driver/include/display_driver/luma/ssd1306.py
+++ b/packages/display_driver/include/display_driver/luma/ssd1306.py
@@ -43,7 +43,7 @@ class SSD1306Display:
         self._page = PAGE_INIT
         self._pages = {PAGE_INIT, PAGE_SHUTDOWN}
         # create buffers
-        self._fragments = {k: dict() for k in self._REGIONS}
+        self.fragments = {k: dict() for k in self._REGIONS}
         self._buffer = np.zeros(
             (
                 self._REGIONS[DisplayRegionID.FULL].height,
@@ -51,7 +51,7 @@ class SSD1306Display:
             ),
             dtype=np.uint8,
         )
-        self._fragments_lock = Semaphore()
+        self.fragments_lock = Semaphore()
         self._device_lock = Semaphore()
         # create internal renderers
         self._pager_renderer = PagerFragmentRenderer()
@@ -62,12 +62,12 @@ class SSD1306Display:
 
     @page.setter
     def page(self, page: int):
-        with self._fragments_lock:
+        with self.fragments_lock:
             self._page = page
         self.render()
 
     def next_page(self):
-        with self._fragments_lock:
+        with self.fragments_lock:
             pages = sorted([p for p in self._pages if p not in (PAGE_INIT, PAGE_SHUTDOWN)])
             # move to the next page
             try:
@@ -116,8 +116,8 @@ class SSD1306Display:
         # threshold image at mid-range
         img = (img > 125).astype(np.uint8) * 255
         # list fragment for rendering
-        with self._fragments_lock:
-            self._fragments[region_id][fragment.name] = DisplayFragment(
+        with self.fragments_lock:
+            self.fragments[region_id][fragment.name] = DisplayFragment(
                 data=img, roi=roi, page=fragment.page, z=fragment.z, _ttl=fragment.ttl, _time=time.time()
             )
 
@@ -131,11 +131,11 @@ class SSD1306Display:
             self.render()
 
     def render(self):
-        with self._fragments_lock:
+        with self.fragments_lock:
             # clean pages
             self._pages = {PAGE_HOME if self._inited else PAGE_INIT}
             # remove expired fragments and annotate how many pages we need
-            for region, fragments in self._fragments.items():
+            for region, fragments in self.fragments.items():
                 for fragment_id in set(fragments.keys()):
                     fragment = fragments[fragment_id]
                     if fragment.ttl() <= 0:
@@ -144,7 +144,7 @@ class SSD1306Display:
                             f"region `{region}` w/ TTL `{fragment.given_ttl}` "
                             f"expired, remove!"
                         )
-                        del self._fragments[region][fragment_id]
+                        del self.fragments[region][fragment_id]
                     if fragment.page != ALL_PAGES:
                         self._pages.add(fragment.page)
             # sanitize page selector
@@ -156,7 +156,7 @@ class SSD1306Display:
                 region: [
                     fragment for fragment in fragments.values() if fragment.page in [ALL_PAGES, self._page]
                 ]
-                for region, fragments in self._fragments.items()
+                for region, fragments in self.fragments.items()
             }
         # add pager fragment
         self._pager_renderer.update(self._pages, self._page)

--- a/packages/display_driver/include/display_driver/types/page.py
+++ b/packages/display_driver/include/display_driver/types/page.py
@@ -5,4 +5,5 @@ PAGE_HOME = 1
 PAGE_ROBOT_INFO = 10
 # NOTE: leave 10 pages for the robot info
 PAGE_TOF = 20
+PAGE_TEST_DISPLAY = 253
 PAGE_SHUTDOWN = 254

--- a/packages/display_driver/include/display_driver_node/main.py
+++ b/packages/display_driver/include/display_driver_node/main.py
@@ -23,6 +23,8 @@ from duckietown_messages.standard.header import Header
 from duckietown_messages.geometry_2d.roi import ROI
 from duckietown_messages.utils.exceptions import DataDecodingError
 
+from display_hardware_test import DisplayHardwareTest
+
 
 @dataclasses.dataclass
 class DisplayNodeConfiguration(NodeConfiguration):
@@ -78,11 +80,15 @@ class DisplayNode(Node):
             self.configuration.frequency,
             self.logger
         )
+        # running test flag
+        self.running_test: bool = False
 
     async def cb_fragments(self, data: RawData):
         """
         Callback processing incoming fragments.
         """
+        if self.running_test:
+            return
         try:
             fragments: DisplayFragments = DisplayFragments.from_rawdata(data)
         except DataDecodingError as e:
@@ -96,6 +102,8 @@ class DisplayNode(Node):
         """
         Callback processing incoming button events.
         """
+        if self.running_test:
+            return
         try:
             event: ButtonEvent = ButtonEvent.from_rawdata(data)
         except DataDecodingError as e:
@@ -113,17 +121,24 @@ class DisplayNode(Node):
     async def worker(self):
         await self.dtps_init(self.configuration)
         # create fragments queue
-        fragments: DTPSContext = await (self.context / "in" / "fragments").queue_create()
+        self.fragments_queue = await (self.context / "in" / "fragments").queue_create()
+        test_in_queue = await (self.context / "test" / "in").queue_create()
+        test_out_queue = await (self.context / "test" / "out").queue_create()
+        # test
+        hardware_test = DisplayHardwareTest(self, test_out_queue, self._display)
         # subscribe to fragments
-        await fragments.subscribe(self.cb_fragments)
+        await self.fragments_queue.subscribe(self.cb_fragments)
+        await test_in_queue.subscribe(hardware_test.on_run_test)
         # expose node to the switchboard
         await self.dtps_expose()
         # expose queues to the switchboard
-        await (self.switchboard / "actuator" / "display" / self.actuator_name / "fragments").expose(fragments)
+        await (self.switchboard / "actuator" / "display" / self.actuator_name / "fragments").expose(self.fragments_queue)
+        await (self.switchboard / "actuator" / "display" / self.actuator_name / "test" / "in").expose(test_in_queue)
+        await (self.switchboard / "actuator" / "display" / self.actuator_name / "test" / "out").expose(test_out_queue)
         # publish the initial state
         timestamp = time.time()
         header = Header(timestamp=timestamp)
-        await fragments.publish(DisplayFragments(
+        await self.fragments_queue.publish(DisplayFragments(
             header=header,
             fragments=(BOOTING_SCREEN, SHUTTING_DOWN_SCREEN)
         ).to_rawdata())

--- a/packages/display_driver/include/display_hardware_test/__init__.py
+++ b/packages/display_driver/include/display_hardware_test/__init__.py
@@ -1,0 +1,1 @@
+from .display_hardware_test import DisplayHardwareTest

--- a/packages/display_driver/include/display_hardware_test/display_hardware_test.py
+++ b/packages/display_driver/include/display_hardware_test/display_hardware_test.py
@@ -1,0 +1,52 @@
+import time
+from typing import Any
+
+from dt_duckiebot_hardware_tests import AbstractHardwareTest
+from dtps import DTPSContext
+from duckietown_messages.actuators.display_fragment import DisplayFragment
+from duckietown_messages.sensors.image import Image
+from duckietown_messages.standard.dictionary import Dictionary
+from duckietown_messages.geometry_2d.roi import ROI
+
+from display_driver.luma.ssd1306 import SSD1306Display
+from display_driver.types.page import PAGE_HOME, PAGE_TEST_DISPLAY
+from display_driver.types.regions import DisplayRegionID
+from display_renderer import monospace_screen
+
+
+class DisplayHardwareTest(AbstractHardwareTest):
+    _display: SSD1306Display
+
+    def __init__(self, node: Any, test_out_queue: DTPSContext, display: SSD1306Display) -> None:
+        super().__init__(node, test_out_queue)
+        self._display = display
+
+    @staticmethod
+    def _get_fragment(text: str) -> DisplayFragment:
+        im = monospace_screen((32, 128), text, scale="hfill")
+        content = Image.from_np(im, encoding="mono8")
+        location = ROI(x=0, y=8, width=128, height=32)
+        return DisplayFragment(
+            name="__display_test__",
+            region=DisplayRegionID.BODY,
+            page=PAGE_TEST_DISPLAY,
+            content=content,
+            location=location,
+            z=0,
+            ttl=-1
+        )
+
+    async def run_test(self, dictionary: Dictionary) -> None:
+        test_id = dictionary.data["test_id"]
+        duration = dictionary.data["duration"]
+        text = dictionary.data["text"]
+        self.message = f"[{test_id}] duration = {duration}, text = '{text}'"
+        fragment = self._get_fragment(text)
+        self._node.running_test = True
+        self._display.add_fragment(fragment)
+        self._display.page = PAGE_TEST_DISPLAY
+        time.sleep(duration)
+        with self._display.fragments_lock:
+            del self._display.fragments[DisplayRegionID.BODY][fragment.name]
+        self._display.page = PAGE_HOME
+        self._node.running_test = False

--- a/packages/display_driver/setup.py
+++ b/packages/display_driver/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 package_name = 'display_driver'
-packages = ["display_driver", "display_driver_node"]
+packages = ["display_driver", "display_driver_node", "display_hardware_test"]
 
 setup(
     name=package_name,

--- a/packages/leds_driver/include/led_hardware_test/__init__.py
+++ b/packages/leds_driver/include/led_hardware_test/__init__.py
@@ -1,0 +1,1 @@
+from .led_hardware_test import LEDHardwareTest

--- a/packages/leds_driver/include/led_hardware_test/led_hardware_test.py
+++ b/packages/leds_driver/include/led_hardware_test/led_hardware_test.py
@@ -1,0 +1,84 @@
+import numpy as np
+import time
+from typing import Any, Dict, List, Tuple, Optional
+
+from colorir import HSV
+from dtps import DTPSContext
+from duckietown_messages.standard.dictionary import Dictionary
+
+from dt_duckiebot_hardware_tests import AbstractHardwareTest
+from leds_driver import LEDsDriverAbs
+
+
+class LEDHardwareTest(AbstractHardwareTest):
+    _color_sequence: Optional[List[Tuple[float, float, float]]]
+    _driver: LEDsDriverAbs
+    _idle_lighting: Dict[str, List]
+    _led_tuple: tuple[str, str, str, str]
+
+    def __init__(
+        self,
+        node: Any,
+        test_out_queue: DTPSContext,
+        driver: LEDsDriverAbs,
+        led_tuple: tuple[str, str, str, str],
+        idle_lighting: Dict[str, List],
+    ) -> None:
+        super().__init__(node, test_out_queue)
+        self._driver = driver
+        self._led_tuple = led_tuple
+        self._idle_lighting = idle_lighting  # set to this after the test
+        self._color_sequence = None  # lazy init. If test is run, generate this
+
+    def _fade_mono(self, led_ids, fade_duration: float, interval: float, fade_in: bool = True, mono_hue: int = 0) -> None:
+        """fade IN or OUT in a mono color"""
+        # number of different colors to show
+        number_of_iterations = int(fade_duration / interval)
+        step_size = float(1 / number_of_iterations)
+        # increasing brightness
+        seq_v: Any = np.arange(0, 1, step_size)
+        if not fade_in:
+            # or decreasing
+            seq_v = reversed(seq_v)
+        for v in seq_v:
+            for led_id in led_ids:
+                hsv = HSV(mono_hue, 1, v)
+                color = hsv.rgb()
+                self._driver.set_rgb(led_id, color)
+            time.sleep(interval)
+
+    def _generate_colors(self, step_size: int = 1) -> List[Tuple[float, float, float]]:
+        """Generate a smooth transition of colors"""
+        colors = []
+        for hue in range(0, 360, step_size):
+            hsv = HSV(hue, 1, 1)
+            color = hsv.rgb()
+            colors.append(color)
+        return colors
+
+    async def run_test(self, dictionary: Dictionary) -> None:
+        test_id = dictionary.data["test_id"]
+        led_ids = dictionary.data["led_ids"]
+        fade_in_duration = dictionary.data["fade_in_duration"]
+        duration = dictionary.data["duration"]
+        fade_out_duration = dictionary.data["fade_out_duration"]
+        self.message = f"[{test_id}] fade_in_duration = {fade_in_duration}s, duration = {duration}s, fade_out_duration = {fade_out_duration}s"
+        # generate test color sequence if not yet initialized
+        if self._color_sequence is None:
+            self._color_sequence = self._generate_colors()
+        color_sequence_length = len(self._color_sequence)
+        interval = duration / float(color_sequence_length)
+        self._node.running_test = True
+        # turn all on gradually
+        self._fade_mono(led_ids, fade_in_duration, interval)
+        # run color sequence test
+        for color in self._color_sequence:
+            for led_id in led_ids:
+                self._driver.set_rgb(led_id, color)
+            time.sleep(interval)
+        # turn all off
+        self._fade_mono(led_ids, fade_out_duration, interval, fade_in=False)
+        # make sure they are set to idle lighting
+        for led_id in led_ids:
+            self._driver.set_rgb(led_id, self._idle_lighting[self._led_tuple[led_id]])
+        self._node.running_test = False

--- a/packages/leds_driver/include/leds_driver/__init__.py
+++ b/packages/leds_driver/include/leds_driver/__init__.py
@@ -1,0 +1,1 @@
+from .leds_driver_abs import LEDsDriverAbs

--- a/packages/leds_driver/include/leds_driver_node/main.py
+++ b/packages/leds_driver/include/leds_driver_node/main.py
@@ -9,7 +9,6 @@ from dt_node_utils import NodeType
 from dt_node_utils.config import NodeConfiguration
 from dt_node_utils.node import Node
 from dt_robot_utils import RobotHardware, get_robot_hardware
-from dtps import DTPSContext
 from dtps_http import RawData
 from duckietown_messages.actuators.car_lights import CarLights
 from duckietown_messages.colors.rgba import RGBA
@@ -17,6 +16,7 @@ from duckietown_messages.standard.header import Header
 from duckietown_messages.utils.exceptions import DataDecodingError
 from hil_support.hil import HardwareInTheLoopSupport, HardwareInTheLoopSide
 from leds_driver.leds_driver_abs import LEDsDriverAbs
+from led_hardware_test import LEDHardwareTest
 
 if get_robot_hardware() == RobotHardware.VIRTUAL:
     from leds_driver.virtual_leds_driver import VirtualLEDsDriver
@@ -24,6 +24,8 @@ if get_robot_hardware() == RobotHardware.VIRTUAL:
 else:
     from leds_driver.leds_driver import PWMLEDsDriver
     LEDsDriver: Type[LEDsDriverAbs] = PWMLEDsDriver
+
+LED_TUPLE = ("front_left", "middle", "front_right", "back_right", "back_left")
 
 
 @dataclasses.dataclass
@@ -53,11 +55,15 @@ class LEDsDriverNode(Node, HardwareInTheLoopSupport):
                                                            from_name(self.package, node_name, config))
         # setup the driver
         self.driver: LEDsDriverAbs = LEDsDriver(debug=False)
+        # running test flag
+        self.running_test: bool = False
 
     async def cb_pattern(self, data: RawData):
         """
         Callback that implements a given light pattern.
         """
+        if self.running_test:
+            return
         try:
             msg: CarLights = CarLights.from_rawdata(data)
         except DataDecodingError as e:
@@ -84,13 +90,26 @@ class LEDsDriverNode(Node, HardwareInTheLoopSupport):
     async def worker(self):
         await self.dtps_init(self.configuration)
         # create RGB queue IN
-        rgb_in: DTPSContext = await (self.context / "in" / "pattern").queue_create()
-        # subscribe to RGB patterns
-        await rgb_in.subscribe(self.cb_pattern)
+        pattern_queue = await (self.context / "in" / "pattern").queue_create()
+        test_front_in_queue = await (self.context / "test" / "front" / "in").queue_create()
+        test_front_out_queue = await (self.context / "test" / "front" / "out").queue_create()
+        test_back_in_queue = await (self.context / "test" / "back" / "in").queue_create()
+        test_back_out_queue = await (self.context / "test" / "back" / "out").queue_create()
+        # tests
+        front_hardware_test = LEDHardwareTest(self, test_front_out_queue, self.driver, LED_TUPLE, self.configuration.initial_pattern)
+        back_hardware_test = LEDHardwareTest(self, test_back_out_queue, self.driver, LED_TUPLE, self.configuration.initial_pattern)
+        # subscriptions
+        await pattern_queue.subscribe(self.cb_pattern)
+        await test_front_in_queue.subscribe(front_hardware_test.on_run_test)
+        await test_back_in_queue.subscribe(back_hardware_test.on_run_test)
         # expose node to the switchboard
         await self.dtps_expose()
         # expose queues to the switchboard
-        await (self.switchboard / "actuator" / "lights" / self.actuator_name / "pattern").expose(rgb_in)
+        await (self.switchboard / "actuator" / "lights" / self.actuator_name / "pattern").expose(pattern_queue)
+        await (self.switchboard / "actuator" / "lights" / self.actuator_name / "test" / "front" / "in").expose(test_front_in_queue)
+        await (self.switchboard / "actuator" / "lights" / self.actuator_name / "test" / "front" / "out").expose(test_front_out_queue)
+        await (self.switchboard / "actuator" / "lights" / self.actuator_name / "test" / "back" / "in").expose(test_back_in_queue)
+        await (self.switchboard / "actuator" / "lights" / self.actuator_name / "test" / "back" / "out").expose(test_back_out_queue)
         # initialize HIL support
         await self.init_hil_support(
             self.context,
@@ -115,7 +134,7 @@ class LEDsDriverNode(Node, HardwareInTheLoopSupport):
             back_left=RGBA.from_list(self.configuration.initial_pattern["back_left"]),
             back_right=RGBA.from_list(self.configuration.initial_pattern["back_right"]),
         )
-        await rgb_in.publish(msg.to_rawdata())
+        await pattern_queue.publish(msg.to_rawdata())
         # run forever
         await self.join()
 

--- a/packages/leds_driver/setup.py
+++ b/packages/leds_driver/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 package_name = 'leds_driver'
-packages = ["leds_driver", "leds_driver_node"]
+packages = ["leds_driver", "leds_driver_node", "led_hardware_test"]
 
 setup(
     name=package_name,

--- a/packages/wheels_driver/include/wheels_driver_node/main.py
+++ b/packages/wheels_driver/include/wheels_driver_node/main.py
@@ -20,7 +20,9 @@ from duckietown_messages.standard.boolean import Boolean
 from duckietown_messages.standard.header import Header
 from duckietown_messages.utils.exceptions import DataDecodingError
 from hil_support.hil import HardwareInTheLoopSupport, HardwareInTheLoopSide
+
 from wheels_driver.wheels_driver_abs import WheelsDriverAbs, WheelPWMConfiguration
+from wheels_hardware_test import WheelsHardwareTest
 
 is_virtual: bool = get_robot_hardware() == RobotHardware.VIRTUAL
 
@@ -77,11 +79,15 @@ class WheelsDriverNode(Node, HardwareInTheLoopSupport):
             left_config=WheelPWMConfiguration(),
             right_config=WheelPWMConfiguration(),
         )
+        # running test flag
+        self.running_test: bool = False
 
     async def cb_wheels_pwm(self, data: RawData):
         """
         Callback that sets wheels' PWM signals.
         """
+        if self.running_test:
+            return
         try:
             pwms: DifferentialPWM = DifferentialPWM.from_rawdata(data)
         except DataDecodingError as e:
@@ -125,17 +131,23 @@ class WheelsDriverNode(Node, HardwareInTheLoopSupport):
 
     async def worker(self):
         await self.dtps_init(self.configuration)
-        # create PWM queue IN
+        # queues
         pwm_in: DTPSContext = await (self.context / "in" / "pwm").queue_create()
-        # create emergency stop queue
         estop_queue: DTPSContext = await (self.context / "in" / "estop").queue_create()
-        # create PWM queues OUT
         self._pwm_filtered_out: DTPSContext = await (self.context / "out" / "pwm_filtered").queue_create()
         self._pwm_executed_out: DTPSContext = await (self.context / "out" / "pwm_executed").queue_create()
-        # subscribe to PWM commands
+        test_left_in_queue = await (self.context / "test" / "left" / "in").queue_create()
+        test_left_out_queue = await (self.context / "test" / "left" / "out").queue_create()
+        test_right_in_queue = await (self.context / "test" / "right" / "in").queue_create()
+        test_right_out_queue = await (self.context / "test" / "right" / "out").queue_create()
+        # test
+        left_hardware_test = WheelsHardwareTest(self, test_left_out_queue, self.driver)
+        right_hardware_test = WheelsHardwareTest(self, test_right_out_queue, self.driver)
+        # subscriptions
         await pwm_in.subscribe(self.cb_wheels_pwm)
-        # subscribe to emergency stop commands
         await estop_queue.subscribe(self.cb_estop)
+        await test_left_in_queue.subscribe(left_hardware_test.on_run_test)
+        await test_right_in_queue.subscribe(right_hardware_test.on_run_test)
         # expose node to the switchboard
         await self.dtps_expose()
         # expose queues to the switchboard
@@ -144,6 +156,10 @@ class WheelsDriverNode(Node, HardwareInTheLoopSupport):
         await (actuator / "estop").expose(estop_queue)
         await (actuator / "pwm_filtered").expose(self._pwm_filtered_out)
         await (actuator / "pwm_executed").expose(self._pwm_executed_out)
+        await (actuator / "test" / "left" / "in").expose(test_left_in_queue)
+        await (actuator / "test" / "left" / "out").expose(test_left_out_queue)
+        await (actuator / "test" / "right" / "in").expose(test_right_in_queue)
+        await (actuator / "test" / "right" / "out").expose(test_right_out_queue)
         # initialize HIL support
         await self.init_hil_support(
             self.context,

--- a/packages/wheels_driver/include/wheels_hardware_test/__init__.py
+++ b/packages/wheels_driver/include/wheels_hardware_test/__init__.py
@@ -1,0 +1,1 @@
+from .wheels_hardware_test import WheelsHardwareTest

--- a/packages/wheels_driver/include/wheels_hardware_test/wheels_hardware_test.py
+++ b/packages/wheels_driver/include/wheels_hardware_test/wheels_hardware_test.py
@@ -1,0 +1,30 @@
+import time
+from typing import Any
+
+from dt_duckiebot_hardware_tests import AbstractHardwareTest
+from dtps import DTPSContext
+from duckietown_messages.standard.dictionary import Dictionary
+from wheels_driver.wheels_driver_abs import WheelsDriverAbs
+
+
+class WheelsHardwareTest(AbstractHardwareTest):
+    _driver: WheelsDriverAbs
+
+    def __init__(self, node: Any, test_out_queue: DTPSContext, driver: WheelsDriverAbs) -> None:
+        super().__init__(node, test_out_queue)
+        self._driver = driver
+
+    async def run_test(self, dictionary: Dictionary) -> None:
+        test_id = dictionary.data["test_id"]
+        info_str = dictionary.data["info_str"]
+        speed = dictionary.data["speed"]
+        duration = dictionary.data["duration"]
+        self.message = f"[{test_id}] speed = {speed}, duration = {duration}s"
+        self._node.running_test = True
+        if info_str == "left":
+            self._driver.set_wheels_speed(speed, 0)
+        else:
+            self._driver.set_wheels_speed(0, speed)
+        time.sleep(duration)
+        self._driver.set_wheels_speed(0, 0)
+        self._node.running_test = False

--- a/packages/wheels_driver/setup.py
+++ b/packages/wheels_driver/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 package_name = 'wheels_driver'
-packages = ['wheels_driver', 'wheels_driver_node']
+packages = ["wheels_driver", "wheels_driver_node", "wheels_hardware_test"]
 
 setup(
     name=package_name,


### PR DESCRIPTION
This pull request introduces hardware test infrastructure for both the button and display drivers, enabling automated hardware validation via dedicated test queues and test logic. It also makes minor improvements to the display driver code structure and adds necessary dependencies for LED hardware testing.

**Hardware test infrastructure:**

* Added `ButtonHardwareTest` and `DisplayHardwareTest` classes, implementing hardware test logic for button and display devices, respectively. These classes allow running hardware tests via DTPS queues and provide feedback on test results. [[1]](diffhunk://#diff-a140d461089ab56ef4583cd15b5c3efa493864946f7433fbefe9e398db4be414R1-R45) [[2]](diffhunk://#diff-57875b774c7b188a909f6a5dc12cda57dcede99bc9fa3279020498536b62ef11R1-R52)
* Integrated hardware test queues into the button and display driver nodes, including creation and exposure of `test/in` and `test/out` queues, and subscription to test commands. [[1]](diffhunk://#diff-455c31b7b8e3a2ddb9f1b7b15fc949742ca616a3997c569ab0c83bbf70b472f1L124-R141) [[2]](diffhunk://#diff-344419d89912ddf6f77dc3bc5da1ffa12601c76e70b520926d79500532b5701eL116-R141)
* Updated `setup.py` in both `button_driver` and `display_driver` packages to include new hardware test modules. [[1]](diffhunk://#diff-211c51a70747e18ca27d87dfe1c1db568be255fea203a527b63dcdda7e7e5071L4-R4) [[2]](diffhunk://#diff-2d28c5271846ca8d151a93dd33a43e5193e8aa34e586f10e271f061a90dca79cL4-R4)
* Added import statements to expose hardware test classes in their respective modules. [[1]](diffhunk://#diff-7c50bd3b03fc80b748ff8b5af63400db2ce355b95e39e0c33280bdb52bea0fdbR1) [[2]](diffhunk://#diff-4b4d8dea3ff846ef264923a7f5b7c3b6342ff0a495b51a5e6b7ebd8eb65b8412R1) [[3]](diffhunk://#diff-aeaa76c4e610350e2638027eca79e06ab99d507675642a2c80246697204111d6R1)

**Button driver enhancements:**

* Added test mode logic to `ButtonDriver`, including methods to start and finish a test, and a callback mechanism for test completion. [[1]](diffhunk://#diff-c1f4c92bbabb9aec34b508668f92083993b551ed235ba7b0017f351a938a3436R49-R52) [[2]](diffhunk://#diff-c1f4c92bbabb9aec34b508668f92083993b551ed235ba7b0017f351a938a3436R63-R79)
* Renamed internal queue variables for clarity (`_queue` to `_event_queue`). [[1]](diffhunk://#diff-455c31b7b8e3a2ddb9f1b7b15fc949742ca616a3997c569ab0c83bbf70b472f1L55-R56) [[2]](diffhunk://#diff-455c31b7b8e3a2ddb9f1b7b15fc949742ca616a3997c569ab0c83bbf70b472f1L71-R72) [[3]](diffhunk://#diff-455c31b7b8e3a2ddb9f1b7b15fc949742ca616a3997c569ab0c83bbf70b472f1L105-R106)

**Display driver improvements:**

* Refactored internal buffer and lock attributes in `SSD1306Display` from private to public names to facilitate access by hardware test logic. [[1]](diffhunk://#diff-40b7d60e43119fc97f6f345a03fe93fabfc47b145bb0f0146876bb630f392e32L46-R54) [[2]](diffhunk://#diff-40b7d60e43119fc97f6f345a03fe93fabfc47b145bb0f0146876bb630f392e32L65-R70) [[3]](diffhunk://#diff-40b7d60e43119fc97f6f345a03fe93fabfc47b145bb0f0146876bb630f392e32L119-R120) [[4]](diffhunk://#diff-40b7d60e43119fc97f6f345a03fe93fabfc47b145bb0f0146876bb630f392e32L134-R138) [[5]](diffhunk://#diff-40b7d60e43119fc97f6f345a03fe93fabfc47b145bb0f0146876bb630f392e32L147-R147) [[6]](diffhunk://#diff-40b7d60e43119fc97f6f345a03fe93fabfc47b145bb0f0146876bb630f392e32L159-R159)
* Added a new display page constant for test display (`PAGE_TEST_DISPLAY`).
* Added a `running_test` flag to prevent normal event/fragment processing during hardware tests. [[1]](diffhunk://#diff-344419d89912ddf6f77dc3bc5da1ffa12601c76e70b520926d79500532b5701eR83-R91) [[2]](diffhunk://#diff-344419d89912ddf6f77dc3bc5da1ffa12601c76e70b520926d79500532b5701eR105-R106)

**Dependencies:**

* Added `colorir` as a dependency for LED hardware tests.