### PR TITLE
Integrate HardwareInTheLoopSupport into IMUNode for enhanced functionality and fix variable name typo

### DIFF
--- a/launchers/sensor-imu.sh
+++ b/launchers/sensor-imu.sh
@@ -12,11 +12,6 @@ source /environment.sh
 SENSOR_NAME="base"
 CONFIG_FILE="${ROBOT_TYPE}/${SENSOR_NAME}/default"
 
-if [ "${ROBOT_HARDWARE}" == "virtual" ]; then
-  echo "Sensor 'imu' not implemented for Virtual robots"
-  exec sleep infinity
-fi
-
 exec python3 \
   -m imu_driver_node.main \
     --sensor-name ${SENSOR_NAME} \

--- a/packages/imu_driver/include/imu_driver/__init__.py
+++ b/packages/imu_driver/include/imu_driver/__init__.py
@@ -1,0 +1,6 @@
+from dt_robot_utils import get_robot_hardware, RobotHardware
+
+if get_robot_hardware() != RobotHardware.VIRTUAL:
+    from imu_driver.imu_driver import IMUDriverCalibratedMPU6050 as IMUDriver
+else:
+    from imu_driver.virtual_imu_driver import VirtualIMUDriver as IMUDriver

--- a/packages/imu_driver/include/imu_driver/imu_driver.py
+++ b/packages/imu_driver/include/imu_driver/imu_driver.py
@@ -8,12 +8,12 @@ from adafruit_mpu6050 import MPU6050
 from smbus2 import SMBus  # NEW
 
 from dtps import DTPSContext
-from .exceptions import DeviceNotFound
+from imu_driver.exceptions import DeviceNotFound
+from imu_driver.imu_driver_abs import IMUDriverAbs
+from imu_driver.types import I2CConnector
 
-from .types import I2CConnector
 
-
-class CalibratedMPU6050:
+class IMUDriverCalibratedMPU6050(IMUDriverAbs):
     WHO_AM_I_REG = 0x75
     ALLOWED_IDS = (0x68, 0x71, 0x98)        # MPU-6050, ICM-2068x
 
@@ -30,23 +30,29 @@ class CalibratedMPU6050:
         self.sensor: Optional[MPU6050] = self._find_sensor()
 
     @property
-    def linear_accelerations(self) -> List[float]:
+    def linear_accelerations(self) -> Optional[List[float]]:
         # apply offsets
+        if self.sensor is None:
+            return None
         return [
             v - self._accelerometer_offsets[i]
             for i, v in enumerate(self.sensor.acceleration)
         ]
 
     @property
-    def angular_velocities(self) -> List[float]:
+    def angular_velocities(self) -> Optional[List[float]]:
         # apply offsets
+        if self.sensor is None:
+            return None
         return [
             v - self._gyroscope_offsets[i]
             for i, v in enumerate(self.sensor.gyro)
         ]
 
     @property
-    def temperature(self) -> float:
+    def temperature(self) -> Optional[float]:
+        if self.sensor is None:
+            return None
         return self.sensor.temperature - self._thermometer_offset
 
     def calibrate_offsets(self):

--- a/packages/imu_driver/include/imu_driver/imu_driver_abs.py
+++ b/packages/imu_driver/include/imu_driver/imu_driver_abs.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+
+class IMUDriverAbs(ABC):
+
+    @property
+    @abstractmethod
+    def linear_accelerations(self) -> Optional[List[float]]:
+        pass
+
+    @property
+    @abstractmethod
+    def angular_velocities(self) -> Optional[List[float]]:
+        pass
+
+    @property
+    @abstractmethod
+    def temperature(self) -> Optional[float]:
+        pass

--- a/packages/imu_driver/include/imu_driver/virtual_imu_driver.py
+++ b/packages/imu_driver/include/imu_driver/virtual_imu_driver.py
@@ -1,0 +1,21 @@
+from typing import Optional, List
+
+from imu_driver.imu_driver_abs import IMUDriverAbs
+
+
+class VirtualIMUDriver(IMUDriverAbs):
+
+    def __init__(self, *_, **__):
+        super(VirtualIMUDriver, self).__init__()
+
+    @property
+    def linear_accelerations(self) -> Optional[List[float]]:
+        return None
+
+    @property
+    def angular_velocities(self) -> Optional[List[float]]:
+        return None
+
+    @property
+    def temperature(self) -> Optional[float]:
+        return None

--- a/packages/imu_driver/include/imu_driver_node/main.py
+++ b/packages/imu_driver/include/imu_driver_node/main.py
@@ -19,6 +19,7 @@ from duckietown_messages.sensors.linear_accelerations import LinearAccelerations
 from duckietown_messages.sensors.temperature import Temperature
 from duckietown_messages.standard.dictionary import Dictionary
 from duckietown_messages.standard.header import Header
+from hil_support.hil import HardwareInTheLoopSide, HardwareInTheLoopSupport
 from imu_driver.exceptions import DeviceNotFound
 from imu_driver.mpu6050 import CalibratedMPU6050
 from imu_driver.types import I2CConnector
@@ -41,7 +42,7 @@ class IMUNodeConfiguration(NodeConfiguration):
     connectors: List[I2CConnector]
 
 
-class IMUNode(Node):
+class IMUNode(Node, HardwareInTheLoopSupport):
     """
     This class implements the communication logic with an IMU sensor on the i2c bus.
     It publishes both measurements and display fragments to show on an LCD screen.
@@ -55,13 +56,14 @@ class IMUNode(Node):
             kind=NodeType.DRIVER,
             description="IMU (Inertia Measurement Unit) sensor driver",
         )
-        self.senor_name: str = sensor_name
+        HardwareInTheLoopSupport.__init__(self)
+        self.sensor_name: str = sensor_name
 
         # load configuration
         self.configuration: IMUNodeConfiguration = IMUNodeConfiguration.from_name(self.package, node_name, config)
 
         # frame
-        self._frame_id: str = f"{self._robot_name}/imu/{self.senor_name}"
+        self._frame_id: str = f"{self._robot_name}/imu/{self.sensor_name}"
 
         # create a IMU sensor handler
         try:
@@ -97,13 +99,32 @@ class IMUNode(Node):
         # expose node to the switchboard
         await self.dtps_expose()
         # expose queues to the switchboard
-        await (self.switchboard / "sensor" / "imu" / self.senor_name / "accelerometer").expose(accelerations_queue)
-        await (self.switchboard / "sensor" / "imu" / self.senor_name / "gyroscope").expose(velocities_queue)
-        await (self.switchboard / "sensor" / "imu" / self.senor_name / "all").expose(all_queue)
-        await (self.switchboard / "sensor" / "imu" / self.senor_name / "temperature").expose(temperature_queue)
+        await (self.switchboard / "sensor" / "imu" / self.sensor_name / "accelerometer").expose(accelerations_queue)
+        await (self.switchboard / "sensor" / "imu" / self.sensor_name / "gyroscope").expose(velocities_queue)
+        await (self.switchboard / "sensor" / "imu" / self.sensor_name / "all").expose(all_queue)
+        await (self.switchboard / "sensor" / "imu" / self.sensor_name / "temperature").expose(temperature_queue)
+        # initialize HIL support
+        await self.init_hil_support(
+            self.context,
+            # source (this is the dynamic side, duckiematrix or nothing)
+            src=None,
+            src_path=["sensor", "imu", self.sensor_name],
+            # destination (this is us, static)
+            dst=self.context,
+            dst_path=["out"],
+            # paths to connect when a remote is set
+            subpaths=["acceleration/linear", "velocity/angular"],
+            # which side is the re-pluggable one
+            side=HardwareInTheLoopSide.SOURCE,
+            # TODO: use transformations to set the frame in the message
+        )
         # read and publish
         dt: float = 1.0 / self.configuration.frequency
         while not self.is_shutdown:
+            # do nothing if HIL is active
+            if self.hil_is_active:
+                await asyncio.sleep(1.0)
+                continue
             try:
                 # read data from the sensors and pack into messages
                 timestamp = time.time()

--- a/packages/imu_driver/include/imu_driver_node/main.py
+++ b/packages/imu_driver/include/imu_driver_node/main.py
@@ -20,8 +20,8 @@ from duckietown_messages.sensors.temperature import Temperature
 from duckietown_messages.standard.dictionary import Dictionary
 from duckietown_messages.standard.header import Header
 from hil_support.hil import HardwareInTheLoopSide, HardwareInTheLoopSupport
+from imu_driver import IMUDriver
 from imu_driver.exceptions import DeviceNotFound
-from imu_driver.mpu6050 import CalibratedMPU6050
 from imu_driver.types import I2CConnector
 
 DEG2RAD = pi / 180.0
@@ -67,7 +67,7 @@ class IMUNode(Node, HardwareInTheLoopSupport):
 
         # create a IMU sensor handler
         try:
-            self._sensor: Optional[CalibratedMPU6050] = CalibratedMPU6050(
+            self._sensor: Optional[IMUDriver] = IMUDriver(
                 self.configuration.connectors, self.context, self.logger
             )
         except DeviceNotFound:
@@ -129,12 +129,12 @@ class IMUNode(Node, HardwareInTheLoopSupport):
                 # read data from the sensors and pack into messages
                 timestamp = time.time()
                 header = Header(timestamp=timestamp)
-                acc: List[float] = self._sensor.linear_accelerations
-                accelerations: LinearAccelerations = LinearAccelerations(header=header, x=acc[0], y=acc[1], z=acc[2])
-                vel: List[float] = self._sensor.angular_velocities
-                velocities: AngularVelocities = AngularVelocities(header=header, x=vel[0]*DEG2RAD, y=vel[1]*DEG2RAD, z=vel[2]*DEG2RAD)
-                temp: float = self._sensor.temperature
-                temperature: Temperature = Temperature(header=header, data=temp)
+                acc: Optional[List[float]] = self._sensor.linear_accelerations
+                accelerations: Optional[LinearAccelerations] = LinearAccelerations(header=header, x=acc[0], y=acc[1], z=acc[2]) if acc is not None else None
+                vel: Optional[List[float]] = self._sensor.angular_velocities
+                velocities: Optional[AngularVelocities] = AngularVelocities(header=header, x=vel[0]*DEG2RAD, y=vel[1]*DEG2RAD, z=vel[2]*DEG2RAD) if vel is not None else None
+                temp: Optional[float] = self._sensor.temperature
+                temperature: Optional[Temperature] = Temperature(header=header, data=temp) if temp is not None else None
             except Exception as e:
                 self.logwarn(f"IMU Comm Loss: {e}")
             else:
@@ -146,10 +146,13 @@ class IMUNode(Node, HardwareInTheLoopSupport):
                 )
 
                 # publish
-                await accelerations_publisher.publish(accelerations.to_rawdata())
-                await velocities_publisher.publish(velocities.to_rawdata())
+                if accelerations is not None:
+                    await accelerations_publisher.publish(accelerations.to_rawdata())
+                if velocities is not None:
+                    await velocities_publisher.publish(velocities.to_rawdata())
                 # await orientation_queue.publish(orientation.to_rawdata())
-                await temperature_publisher.publish(temperature.to_rawdata())
+                if temperature is not None:
+                    await temperature_publisher.publish(temperature.to_rawdata())
                 await all_publisher.publish(imu_message.to_rawdata())
             finally:
                 # wait


### PR DESCRIPTION
This pull request enhances the IMU driver node by integrating hardware-in-the-loop (HIL) support and fixing a naming bug. The most significant changes are the addition of HIL functionality for dynamic/static sensor data routing and the correction of a typo in the sensor name variable, which improves code reliability and clarity.

### Hardware-in-the-loop (HIL) integration

* Imported HIL support classes (`HardwareInTheLoopSide`, `HardwareInTheLoopSupport`) from `hil_support.hil` to enable HIL features in the IMU node.
* Updated the `IMUNode` class to inherit from `HardwareInTheLoopSupport`, enabling it to participate in HIL workflows.
* Initialized HIL support in the node's worker method, configuring dynamic/static data routing and specifying which sensor data paths are re-pluggable.
* Added logic to pause sensor data publishing when HIL is active, ensuring that only the appropriate data source is used during HIL testing.

### Bug fix and code cleanup

* Corrected a typo in the sensor name variable (`senor_name` → `sensor_name`) throughout the codebase, fixing queue exposure paths and frame identifiers to use the correct variable. [[1]](diffhunk://#diff-0de0dc5ad28ea251439eb6f4a9f9594d72232fac547f64f3650ba859ba0db0b9L58-R66) [[2]](diffhunk://#diff-0de0dc5ad28ea251439eb6f4a9f9594d72232fac547f64f3650ba859ba0db0b9L100-R127)