### PR TITLE
Update IMUNode subpaths to include 'all' for enhanced data routing

### DIFF
--- a/packages/imu_driver/include/imu_driver_node/main.py
+++ b/packages/imu_driver/include/imu_driver_node/main.py
@@ -113,7 +113,7 @@ class IMUNode(Node, HardwareInTheLoopSupport):
             dst=self.context,
             dst_path=["out"],
             # paths to connect when a remote is set
-            subpaths=["acceleration/linear", "velocity/angular"],
+            subpaths=["acceleration/linear", "velocity/angular", "all"],
             # which side is the re-pluggable one
             side=HardwareInTheLoopSide.SOURCE,
             # TODO: use transformations to set the frame in the message


### PR DESCRIPTION
This pull request makes a minor update to the `worker` method in `main.py` to expand the set of subpaths used for remote connections.

* Added `"all"` to the `subpaths` list in the `worker` method, allowing for broader data routing when a remote is set.