### PR TITLE
DTSW-7602-Add-more-information-to-the-Duckiebot-display

### DIFF
--- a/packages/display_renderer/config/interaction_plate/default.yaml
+++ b/packages/display_renderer/config/interaction_plate/default.yaml
@@ -4,4 +4,4 @@ renderers:
   network:
     frequency: 0.2
   robot_info:
-    frequency: 0.05
+    frequency: 1

--- a/packages/display_renderer/include/display_renderer_node/main.py
+++ b/packages/display_renderer/include/display_renderer_node/main.py
@@ -377,20 +377,66 @@ class RobotInfoRenderer(MultipageTextFragmentRenderer):
     async def step(self):
         if self._data is None:
             return
+        hardware: dict = self._data["hardware"]
+        board: str = hardware["board"]
+        model: str = hardware["model"]
+        revision: str = hardware["revision"]
         firmware: str = f"v{self._data['software']['version']}"
         distro: str = os.environ.get('DT_DISTRO', 'N.A.')
         ip: str = self.get_local_ip_address_on_gateway_interface() or "N.A."
-        # format texts for the display
-        text: str = self._fmt({
+        data = {
             "Name": get_robot_name(),
             "Model": get_robot_configuration().name,
+            "Hardware": board + " " + model + f" ({revision})",
             "Firmware": firmware,
             "Distro": distro,
-            # NOTE: IP uses two lines
-            "IP": "", "": ip
-        })
+            "IP": ip,
+            "Battery": "Not detected",
+            "L motor": "Not detected",
+            "R motor": "Not detected",
+            "Camera": "Not detected",
+            "ToF": "Not detected",
+            "IMU": "Not detected"
+        }
+        for component in self._data["components"]:
+            if component["detected"]:
+                if component["key"] == "battery":
+                    data["Battery"] = "Detected"
+                elif component["key"] == "motor/left":
+                    data["L motor"] = "Detected"
+                elif component["key"] == "motor/right":
+                    data["R motor"] = "Detected"
+                elif component["key"] == "camera":
+                    data["Camera"] = "Detected"
+                elif component["key"] == "tof/front-center":
+                    data["ToF"] = "Detected"
+                elif component["key"] == "imu":
+                    data["IMU"] = "Detected"
+            if component["key"] == "motor/left":
+                data["L motor"] = self.get_calibratable_component_text(
+                    data["L motor"], 
+                    component["calibration"])
+            elif component["key"] == "motor/right":
+                data["R motor"] = self.get_calibratable_component_text(
+                    data["R motor"], 
+                    component["calibration"])
+            elif component["key"] == "camera":
+                data["Camera"] = self.get_calibratable_component_text(
+                    data["Camera"], 
+                    component["calibration"])
+        # format texts for the display
+        text: str = self._fmt(data)
         # update the underlying text renderer
         super().update(text)
+
+    @staticmethod
+    def get_calibratable_component_text(component_text: str, calibration: dict) -> str:
+        if calibration["needed"]:
+            if component_text == "Detected":
+                component_text += " and calibrated" if calibration["completed"] else " but not calibrated"
+            else:
+                component_text += " but calibrated" if calibration["completed"] else " and not calibrated"
+        return component_text
 
     @staticmethod
     def get_local_ip_address_on_gateway_interface() -> Optional[str]:

--- a/packages/display_renderer/include/display_renderer_node/main.py
+++ b/packages/display_renderer/include/display_renderer_node/main.py
@@ -345,16 +345,24 @@ class RobotInfoRenderer(MultipageTextFragmentRenderer):
         )
         # data
         self._data: Optional[dict] = None
+        # scroll state
+        self._scroll_offset: int = 0
 
-    @staticmethod
-    def _shorten_str(value):
-        """If the input is longer than the allowed, it's trimmed and '...' is added"""
+    def _shorten_str(self, value):
+        """If the input is longer than the allowed, it scrolls through the text"""
         # maximum length of the value
         max_length: int = 8
-        output = value
-        if len(value) > max_length:
-            output = value[:(max_length - 3)] + "..."
-        return output
+        if len(value) <= max_length:
+            return value
+        # add padding for smooth scroll loop
+        scrollable_text = value + "   "
+        # calculate scroll position
+        offset = self._scroll_offset % len(scrollable_text)
+        # extract visible window
+        visible = ""
+        for i in range(max_length):
+            visible += scrollable_text[(offset + i) % len(scrollable_text)]
+        return visible
 
     def _fmt(self, data: Dict[str, str]) -> str:
         # length of the longest line
@@ -377,6 +385,8 @@ class RobotInfoRenderer(MultipageTextFragmentRenderer):
     async def step(self):
         if self._data is None:
             return
+        # update scroll position every frame
+        self._scroll_offset += 1
         hardware: dict = self._data["hardware"]
         board: str = hardware["board"]
         model: str = hardware["model"]


### PR DESCRIPTION
This pull request introduces improvements to the display renderer’s hardware info panel, focusing on enhanced hardware component reporting and a smoother user experience for long text fields. The most significant changes include implementing a scrolling mechanism for long strings, expanding the displayed hardware and component status, and updating the reporting logic for calibration status.

**Display improvements:**

* The `_shorten_str` method in `main.py` now scrolls long text fields instead of simply truncating them, allowing users to view the full content over time.
* The `step` method increments the scroll offset every frame, enabling the scrolling effect for hardware info fields.

**Hardware reporting enhancements:**

* The hardware info panel now displays additional component statuses (Battery, L motor, R motor, Camera, ToF, IMU). Each is marked as "Detected" or "Not detected" based on the robot's current state.
* The calibration status for calibratable components (motors, camera) is now included in the display, with clear messaging about whether calibration is needed and completed.
* The update frequency for `robot_info` in `default.yaml` was increased from 0.05 to 1, ensuring more frequent updates to the hardware info panel.