### PR TITLE
DTSW-7838 Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/packages/flight_controller_driver/utils/network_serial.py
+++ b/packages/flight_controller_driver/utils/network_serial.py
@@ -2,7 +2,7 @@ import socket
 import serial
 
 # Configuration
-HOST = '0.0.0.0'  # Listen on all network interfaces
+HOST = '127.0.0.1'  # Listen on loopback interface only
 PORT = 12345  # Port to listen on for incoming connections
 SERIAL_PORT = '/dev/ttyACM{}'  # Serial port to which data will be sent
 BAUD_RATE = 1e6  # Baud rate for the serial communication


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-duckiebot-interface/security/code-scanning/4](https://github.com/duckietown/dt-duckiebot-interface/security/code-scanning/4)

To fix this without changing core functionality, bind the server socket to a specific interface instead of all interfaces. The safest default is loopback (`127.0.0.1`), which keeps the service local to the host. If remote access is required, this constant can be changed to a specific trusted interface IP.

**Best single fix in this file:**
- In `packages/flight_controller_driver/utils/network_serial.py`, change the `HOST` constant from `'0.0.0.0'` to `'127.0.0.1'`.
- Keep the rest of the socket setup unchanged so behavior is preserved except for exposure scope.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
