### PR TITLE
DTSW-7838 Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-jira-key:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-duckiebot-interface/security/code-scanning/2](https://github.com/duckietown/dt-duckiebot-interface/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained.  
Best fix without changing behavior: set workflow-level permissions to read-only for repository contents:

- File: `.github/workflows/jira-pr-check.yml`
- Insert at the top level (after `on:` block and before `jobs:`):
  - `permissions:`
  - `contents: read`

This job only inspects PR title/branch from event payload and does not need write scopes, so `contents: read` is a safe minimal explicit permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
