### PR TITLE
DTSW-7838 Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,4 +1,7 @@
 on: [status]
+permissions:
+  contents: read
+  packages: read
 jobs:
    circleci_artifacts_redirector_job:
      runs-on: ubuntu-latest

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,7 +1,7 @@
 on: [status]
 permissions:
   contents: read
-  packages: read
+  statuses: write
 jobs:
    circleci_artifacts_redirector_job:
      runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-duckiebot-interface/security/code-scanning/1](https://github.com/duckietown/dt-duckiebot-interface/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/circleci.yml` so the workflow does not inherit potentially over-broad defaults.  
Best single fix (without changing existing behavior) is to set read-only baseline permissions at the workflow root:

- `contents: read` (commonly required for repository metadata/content access)
- `packages: read` (safe minimal read scope often included in baseline guidance)

This keeps the existing job and steps intact while explicitly constraining `GITHUB_TOKEN` scopes for all jobs in this workflow.  
Edit region: top of `.github/workflows/circleci.yml`, directly after the `on:` line and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
