### PR TITLE
DTSW-7992: fix DD24 ToF default I2C buses for TCA9548A mux

### DIFF
--- a/packages/tof_driver/config/duckiedrone/bottom/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/bottom/default.yaml
@@ -5,7 +5,7 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # bottom ToF -> mux channel 0 (i2c-23)
+  # bottom ToF -> port CHL0
   -   bus: 23
       address: 0x29
 

--- a/packages/tof_driver/config/duckiedrone/bottom/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/bottom/default.yaml
@@ -10,5 +10,6 @@ connectors:
       address: 0x29
 
   # Raspberry Pi 5
+  # TODO: verify bus on Pi 5
   -   bus: 11
       address: 0x29

--- a/packages/tof_driver/config/duckiedrone/bottom/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/bottom/default.yaml
@@ -4,9 +4,9 @@ frequency: 30
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
-  # DD24 - One ToF sensor connected directly to the HUT
   # Raspberry Pi 4
-  -   bus: 22
+  # bottom ToF -> mux channel 0 (i2c-23)
+  -   bus: 23
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/front/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/front/default.yaml
@@ -10,5 +10,6 @@ connectors:
       address: 0x29
 
   # Raspberry Pi 5
+  # TODO: verify bus on Pi 5
   -   bus: 11
       address: 0x29

--- a/packages/tof_driver/config/duckiedrone/front/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/front/default.yaml
@@ -4,9 +4,9 @@ frequency: 30
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
-  # DD24 - One ToF sensor connected directly to the HUT
   # Raspberry Pi 4
-  -   bus: 22
+  # front ToF -> mux channel 1 (i2c-24)
+  -   bus: 24
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/front/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/front/default.yaml
@@ -5,8 +5,8 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # front ToF -> mux channel 1 (i2c-24)
-  -   bus: 24
+  # front ToF -> port CHL4
+  -   bus: 27
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/left/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/left/default.yaml
@@ -5,8 +5,8 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # left ToF -> mux channel 3 (i2c-26)
-  -   bus: 26
+  # left ToF -> port CHL1
+  -   bus: 24
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/left/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/left/default.yaml
@@ -10,5 +10,6 @@ connectors:
       address: 0x29
 
   # Raspberry Pi 5
+  # TODO: verify bus on Pi 5
   -   bus: 11
       address: 0x29

--- a/packages/tof_driver/config/duckiedrone/left/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/left/default.yaml
@@ -4,9 +4,9 @@ frequency: 30
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
-  # DD24 - One ToF sensor connected directly to the HUT
   # Raspberry Pi 4
-  -   bus: 22
+  # left ToF -> mux channel 3 (i2c-26)
+  -   bus: 26
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/right/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/right/default.yaml
@@ -5,7 +5,7 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # right ToF -> mux channel 2 (i2c-25)
+  # right ToF -> port CHL2
   -   bus: 25
       address: 0x29
 

--- a/packages/tof_driver/config/duckiedrone/right/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/right/default.yaml
@@ -10,5 +10,6 @@ connectors:
       address: 0x29
 
   # Raspberry Pi 5
+  # TODO: verify bus on Pi 5
   -   bus: 11
       address: 0x29

--- a/packages/tof_driver/config/duckiedrone/right/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/right/default.yaml
@@ -4,9 +4,9 @@ frequency: 30
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
-  # DD24 - One ToF sensor connected directly to the HUT
   # Raspberry Pi 4
-  -   bus: 22
+  # right ToF -> mux channel 2 (i2c-25)
+  -   bus: 25
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/top/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/top/default.yaml
@@ -4,9 +4,9 @@ frequency: 30
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
-  # DD24 - One ToF sensor connected directly to the HUT
   # Raspberry Pi 4
-  -   bus: 22
+  # top ToF -> mux channel 4 (i2c-27)
+  -   bus: 27
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/top/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/top/default.yaml
@@ -5,8 +5,8 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # top ToF -> mux channel 4 (i2c-27)
-  -   bus: 27
+  # top ToF -> port CHL3
+  -   bus: 26
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/top/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/top/default.yaml
@@ -10,5 +10,6 @@ connectors:
       address: 0x29
 
   # Raspberry Pi 5
+  # TODO: verify bus on Pi 5
   -   bus: 11
       address: 0x29


### PR DESCRIPTION
## What
Point each duckiedrone ToF default config at its TCA9548A mux channel instead of the old direct `bus: 22`.

| Sensor | Port | Bus |
|--------|------|-----|
| bottom | CHL0 | 23 |
| left   | CHL1 | 24 |
| right  | CHL2 | 25 |
| top    | CHL3 | 26 |
| front  | CHL4 | 27 |

Pi 5 (`bus: 11`) fallback retained; only the Pi 4 bus number changed in each file.

## Why
On DD24 every ToF sensor is wired through a **TCA9548A I2C mux** (`1-0077`, addr `0x77` on root bus 1), not directly to the Pi's I2C. The kernel exposes each mux channel as its own `/dev/i2c-N`:

