### PR TITLE
DTSW-8001-Add-support-for-every-ToF-sensor

### DIFF
--- a/launchers/sensor-tof-front.sh
+++ b/launchers/sensor-tof-front.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source /environment.sh
+
+# YOUR CODE BELOW THIS LINE
+# ----------------------------------------------------------------------------
+
+
+# NOTE: Use the variable DT_PROJECT_PATH to know the absolute path to your code
+# NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
+
+SENSOR_NAME="front"
+CONFIG_FILE="default"
+
+exec python3 \
+  -m tof_driver_node.main \
+    --sensor-name ${SENSOR_NAME} \
+    --config ${ROBOT_TYPE}/${SENSOR_NAME}/${CONFIG_FILE}
+
+
+# ----------------------------------------------------------------------------
+# YOUR CODE ABOVE THIS LINE

--- a/launchers/sensor-tof-left.sh
+++ b/launchers/sensor-tof-left.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source /environment.sh
+
+# YOUR CODE BELOW THIS LINE
+# ----------------------------------------------------------------------------
+
+
+# NOTE: Use the variable DT_PROJECT_PATH to know the absolute path to your code
+# NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
+
+SENSOR_NAME="left"
+CONFIG_FILE="default"
+
+exec python3 \
+  -m tof_driver_node.main \
+    --sensor-name ${SENSOR_NAME} \
+    --config ${ROBOT_TYPE}/${SENSOR_NAME}/${CONFIG_FILE}
+
+
+# ----------------------------------------------------------------------------
+# YOUR CODE ABOVE THIS LINE

--- a/launchers/sensor-tof-right.sh
+++ b/launchers/sensor-tof-right.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source /environment.sh
+
+# YOUR CODE BELOW THIS LINE
+# ----------------------------------------------------------------------------
+
+
+# NOTE: Use the variable DT_PROJECT_PATH to know the absolute path to your code
+# NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
+
+SENSOR_NAME="right"
+CONFIG_FILE="default"
+
+exec python3 \
+  -m tof_driver_node.main \
+    --sensor-name ${SENSOR_NAME} \
+    --config ${ROBOT_TYPE}/${SENSOR_NAME}/${CONFIG_FILE}
+
+
+# ----------------------------------------------------------------------------
+# YOUR CODE ABOVE THIS LINE

--- a/launchers/sensor-tof-top.sh
+++ b/launchers/sensor-tof-top.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source /environment.sh
+
+# YOUR CODE BELOW THIS LINE
+# ----------------------------------------------------------------------------
+
+
+# NOTE: Use the variable DT_PROJECT_PATH to know the absolute path to your code
+# NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
+
+SENSOR_NAME="top"
+CONFIG_FILE="default"
+
+exec python3 \
+  -m tof_driver_node.main \
+    --sensor-name ${SENSOR_NAME} \
+    --config ${ROBOT_TYPE}/${SENSOR_NAME}/${CONFIG_FILE}
+
+
+# ----------------------------------------------------------------------------
+# YOUR CODE ABOVE THIS LINE


### PR DESCRIPTION
This pull request introduces new launcher scripts for running the Time-of-Flight (ToF) sensor driver node for different sensor positions on the robot. Each script sets up the environment and launches the driver with the appropriate sensor name and configuration.

New launcher scripts for ToF sensors:

* Added `sensor-tof-front.sh` to launch the ToF driver for the front sensor position.
* Added `sensor-tof-left.sh` to launch the ToF driver for the left sensor position.
* Added `sensor-tof-right.sh` to launch the ToF driver for the right sensor position.
* Added `sensor-tof-top.sh` to launch the ToF driver for the top sensor position.