### PR TITLE
DTSW-8066-Move-camera-driver-to-dt-duckiebot-interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,59 @@ ENV DT_PROJECT_NAME="${PROJECT_NAME}" \
 COPY ./dependencies-apt.txt "${PROJECT_PATH}/"
 RUN dt-apt-install ${PROJECT_PATH}/dependencies-apt.txt
 
+# Build libcamera from the Raspberry Pi fork so we have the OV5647 fixes that
+# landed after 0.2. Ubuntu Noble ships libcamera 0.2.0, which trips a
+# `prepareIsp()` IPA-buffer assertion on the Duckiedrone's OV5647 sensor.
+ARG LIBCAMERA_REF=v0.4.0
+RUN set -eux; \
+    git clone --depth 1 --branch "${LIBCAMERA_REF}" \
+        https://github.com/raspberrypi/libcamera.git /tmp/libcamera; \
+    cd /tmp/libcamera; \
+    meson setup build \
+        --prefix=/usr \
+        --buildtype=release \
+        -Dipas=rpi/vc4 \
+        -Dpipelines=rpi/vc4 \
+        -Dpycamera=enabled \
+        -Ddocumentation=disabled \
+        -Dgstreamer=disabled \
+        -Dv4l2=true \
+        -Dtest=false \
+        -Dcam=disabled \
+        -Dqcam=disabled \
+        -Dlc-compliance=disabled; \
+    ninja -C build install; \
+    ldconfig; \
+    cd /; rm -rf /tmp/libcamera
+
+# libcamera's meson install drops the Python bindings under
+# /usr/lib/python<ver>/site-packages/, which Ubuntu Noble's Python doesn't
+# auto-include. Expose it via a .pth file so `import libcamera` works.
+RUN set -e; \
+    pyver="$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')"; \
+    lc_parent="$(python3 -c "import glob,os;hits=glob.glob('/usr/lib/python*/site-packages/libcamera')+glob.glob('/usr/lib/python*/dist-packages/libcamera')+glob.glob('/usr/lib/*/python*/site-packages/libcamera');print(os.path.dirname(hits[0]) if hits else '')")"; \
+    if [ -z "${lc_parent}" ]; then \
+        echo "ERROR: libcamera Python bindings not found after install" >&2; exit 1; \
+    fi; \
+    mkdir -p "/usr/local/lib/python${pyver}/dist-packages"; \
+    echo "${lc_parent}" > "/usr/local/lib/python${pyver}/dist-packages/libcamera.pth"; \
+    echo "libcamera Python bindings: ${lc_parent}"
+
 # install python3 dependencies
 ARG PIP_INDEX_URL="https://pypi.org/simple"
 ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 COPY ./dependencies-py3.* "${PROJECT_PATH}/"
 RUN dt-pip3-install "${PROJECT_PATH}/dependencies-py3.*"
+
+# picamera2.previews/__init__.py eagerly imports drm_preview, which needs
+# pykms (python3-kms++). That package is not available on Noble and we run
+# headless, so soften the import to tolerate ImportError.
+RUN set -e; \
+    pyver="$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')"; \
+    previews_init="/usr/local/lib/python${pyver}/dist-packages/picamera2/previews/__init__.py"; \
+    if [ -f "${previews_init}" ] && ! grep -q "except ImportError" "${previews_init}"; then \
+        sed -i 's|^from .drm_preview import DrmPreview$|try:\n    from .drm_preview import DrmPreview\nexcept ImportError:\n    DrmPreview = None|' "${previews_init}"; \
+    fi
 
 # copy the source code
 COPY ./packages "${PROJECT_PATH}/packages"

--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -17,5 +17,26 @@ gstreamer1.0-tools
 # tool needed to setup camera
 v4l-utils
 
+# Raspberry Pi CSI camera support
+git
+meson
+ninja-build
+pkg-config
+python3-dev
+python3-jinja2
+python3-ply
+python3-yaml
+pybind11-dev
+libyaml-dev
+libssl-dev
+libgnutls28-dev
+libudev-dev
+libevent-dev
+libcap-dev
+libdw-dev
+libunwind-dev
+libboost-dev
+libjpeg-turbo8-dev
+
 # tools for betaflight SITL
 socat

--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -6,6 +6,9 @@ Jetson.GPIO==2.1.9
 # RPi packages
 RPi.GPIO==0.7.1
 
+# Raspberry Pi camera Python API
+picamera2==0.3.36
+
 # dependencies for the OLED display
 luma.oled==3.13.0
 

--- a/packages/camera_driver/include/camera_driver_node/raspberry_pi_64.py
+++ b/packages/camera_driver/include/camera_driver_node/raspberry_pi_64.py
@@ -2,7 +2,7 @@
 
 import atexit
 import subprocess
-from typing import cast
+from typing import Any, Optional, Tuple, cast
 import cv2
 import asyncio
 import argparse
@@ -16,13 +16,137 @@ class CameraNode(CameraNodeAbs):
     Handles the imagery on a Raspberry Pi.
     """
     VIDEO_DEVICE = "/dev/video0"
+    JPEG_QUALITY = 90
+    ROTATION_QUADRANTS = {
+        0: 0,
+        90: 3,
+        180: 2,
+        270: 1,
+    }
 
     def __init__(self, config: str, sensor_name: str):
         # Initialize the DTROS parent class
         super(CameraNode, self).__init__(config, sensor_name)
-        # prepare gstreamer pipeline
-        self._device = None
+        self._device: Optional[Any] = None
+        self._use_picamera2 = False
         self.loginfo("[CameraNode]: Initialized.")
+
+    def _get_capture_size(self) -> Tuple[int, int]:
+        capture_width = self.configuration.res_w
+        capture_height = self.configuration.res_h
+        rotation = self.configuration.rotation % 360
+        if rotation in (90, 270):
+            capture_width = self.configuration.res_h
+            capture_height = self.configuration.res_w
+        return capture_width, capture_height
+
+    def _rotate_image(self, image: np.ndarray) -> np.ndarray:
+        rotation = self.configuration.rotation % 360
+        rotation_quadrants = self.ROTATION_QUADRANTS.get(rotation, 0)
+        if rotation_quadrants:
+            return np.rot90(image, k=rotation_quadrants)
+        return image
+
+    def _encode_jpeg(self, image: np.ndarray) -> Optional[bytes]:
+        encode_parameters = [cv2.IMWRITE_JPEG_QUALITY, self.JPEG_QUALITY]
+        success, encoded = cv2.imencode(".jpg", image, encode_parameters)
+        if not success:
+            return None
+        return encoded.tobytes()
+
+    def _capture_jpeg(self) -> Optional[bytes]:
+        if self._device is None:
+            return None
+        if self._use_picamera2:
+            image = self._device.capture_array()
+            if image is None:
+                return None
+        else:
+            video_capture = cast(cv2.VideoCapture, self._device)
+            success, image = video_capture.read()
+            if not success or image is None:
+                return None
+        image_array = cast(np.ndarray, image)
+        rotated_image = self._rotate_image(image_array)
+        return self._encode_jpeg(rotated_image)
+
+    def _set_optional_v4l2_control(self, key: str, value: int):
+        command = ["v4l2-ctl", "-d", self.VIDEO_DEVICE, "-c", f"{key}={value}"]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        if result.returncode == 0:
+            return
+        reason = result.stderr.strip()
+        if not reason:
+            reason = result.stdout.strip()
+        if reason:
+            self.logwarn(f"Skipping unsupported camera control '{key}': {reason}")
+
+    def _try_picamera2(self) -> bool:
+        try:
+            from picamera2 import Picamera2
+        except ImportError:
+            self.logwarn("picamera2 not installed; skipping libcamera path")
+            return False
+        camera = None
+        capture_width, capture_height = self._get_capture_size()
+        try:
+            camera = Picamera2()
+            video_configuration = camera.create_video_configuration(
+                main={"format": "RGB888", "size": (capture_width, capture_height)},
+                controls={"FrameRate": float(self.configuration.framerate)},
+            )
+            camera.configure(video_configuration)
+            if self.configuration.exposure_mode == "sports":
+                self.loginfo("Setting exposure to 'sports' mode.")
+                camera.set_controls({"AeExposureMode": 1})
+            camera.start()
+            first_frame = camera.capture_array()
+            if first_frame is None:
+                raise RuntimeError("picamera2 opened but first frame was empty")
+            self._device = camera
+            self._use_picamera2 = True
+            self.loginfo("Camera opened via picamera2 (libcamera)")
+            return True
+        except Exception as exc:
+            if camera is not None:
+                try:
+                    camera.stop()
+                except Exception as stop_exc:
+                    self.logwarn(f"Failed to stop picamera2 during cleanup: {stop_exc}")
+                try:
+                    camera.close()
+                except Exception as close_exc:
+                    self.logwarn(f"Failed to close picamera2 during cleanup: {close_exc}")
+            self.logwarn(f"picamera2 failed: {exc}")
+            return False
+
+    def _open_v4l2(self):
+        self._set_optional_v4l2_control("video_bitrate", 25000000)
+        if self._device is None:
+            self._device = cv2.VideoCapture()
+        video_capture = cast(cv2.VideoCapture, self._device)
+        if video_capture.isOpened():
+            return
+        capture_width, capture_height = self._get_capture_size()
+        try:
+            video_capture.open(self.VIDEO_DEVICE, cv2.CAP_V4L2)
+            if not video_capture.isOpened():
+                raise RuntimeError("OpenCV cannot open camera")
+            video_capture.set(cv2.CAP_PROP_FRAME_WIDTH, capture_width)
+            video_capture.set(cv2.CAP_PROP_FRAME_HEIGHT, capture_height)
+            video_capture.set(cv2.CAP_PROP_FPS, self.configuration.framerate)
+            if self.configuration.exposure_mode == "sports":
+                self.loginfo("Setting exposure to 'sports' mode.")
+                video_capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.75)
+                if self.configuration.exposure is not None:
+                    video_capture.set(cv2.CAP_PROP_EXPOSURE, self.configuration.exposure)
+            self._use_picamera2 = False
+            if self._capture_jpeg() is None:
+                raise RuntimeError("Could not read image from camera")
+            self.loginfo(f"Camera opened via V4L2 ({self.VIDEO_DEVICE})")
+        except Exception as exc:
+            self.stop()
+            raise RuntimeError(f"Could not start camera: {exc}")
 
     async def worker(self):
         """
@@ -30,85 +154,38 @@ class CameraNode(CameraNodeAbs):
 
         Captures a frame from the /dev/video0 image sink and publishes it.
         """
-        if self._device is None or not self._device.isOpened():
+        if self._device is None:
             self.logerr("Device was found closed")
             return
         # init queues
         await self.dtps_init_queues()
-        # get first frame
-        retval, image = self._device.read() if self._device else (False, None)
 
         # keep reading
         while not self.is_shutdown:
-            if not retval:
+            jpeg = self._capture_jpeg()
+            if jpeg is None:
                 self.logerr("Could not read image from camera")
                 await asyncio.sleep(1)
                 continue
-            if image is not None:
-                # without HW acceleration, the image is returned as RGB, encode on CPU
-                jpeg: bytes = cast(np.ndarray, image).tobytes()
-
-                # publish
-                await self.publish(jpeg)
+            await self.publish(jpeg)
             # return control to the event loop
             await asyncio.sleep(0.001)
-            # grab next frame
-            retval, image = self._device.read() if self._device else (False, None)
         self.loginfo("Camera worker stopped.")
 
     def setup(self):
-        # setup camera
-        cam_props = {
-            "video_bitrate": 25000000,
-        }
-        for key in cam_props:
-            subprocess.call(
-                f"v4l2-ctl -d {CameraNode.VIDEO_DEVICE} -c {key}={str(cam_props[key])}", shell=True
-            )
-        # create VideoCapture object
-        if self._device is None:
-            self._device = cv2.VideoCapture()
-        # open the device
-        if not self._device.isOpened():
-            try:
-                self._device.open(CameraNode.VIDEO_DEVICE, cv2.CAP_V4L2)
-                # make sure the device is open
-                if not self._device.isOpened():
-                    msg = "OpenCV cannot open camera"
-                    self.logerr(msg)
-                    raise RuntimeError(msg)
-                # configure camera
-                self._device.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
-                self._device.set(cv2.CAP_PROP_FRAME_WIDTH, self.configuration.res_w)
-                self._device.set(cv2.CAP_PROP_FRAME_HEIGHT, self.configuration.res_h)
-                self._device.set(cv2.CAP_PROP_ROLL, self.configuration.rotation)
-                self._device.set(cv2.CAP_PROP_FPS, self.configuration.framerate)
-                self._device.set(cv2.CAP_PROP_CONVERT_RGB, 0.0)
-                # Set auto exposure to false
-                if self.configuration.exposure_mode == "sports":
-                    msg = "Setting exposure to 'sports' mode."
-                    self.loginfo(msg)
-                    self._device.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.75)
-                    self._device.set(cv2.CAP_PROP_EXPOSURE, self.configuration.exposure)
-                # try getting a sample image
-                retval, _ = self._device.read()
-                if not retval:
-                    msg = "Could not read image from camera"
-                    self.logerr(msg)
-                    raise RuntimeError(msg)
-            except (Exception, RuntimeError):
-                self.stop()
-                msg = "Could not start camera"
-                self.logerr(msg)
-                raise RuntimeError(msg)
-            # register self.close as cleanup function
+        if self._try_picamera2():
             atexit.register(self.stop)
+            return
+        try:
+            self._open_v4l2()
+        except RuntimeError as exc:
+            self.logerr(str(exc))
+            raise
+        atexit.register(self.stop)
 
     def on_shutdown(self):
         super().on_shutdown()
-        if self._device is not None:
-            self._device.release()
-        self.loginfo("OpenCV device released.")
+        self.release()
 
     def stop(self):
         """
@@ -119,13 +196,23 @@ class CameraNode(CameraNodeAbs):
     def release(self, force: bool = False):
         if self._device is not None:
             self.loginfo("Releasing camera...")
-            # noinspection PyBroadException
-            try:
-                self._device.release()
-            except Exception:
-                pass
+            if self._use_picamera2:
+                try:
+                    self._device.stop()
+                except Exception as exc:
+                    self.logerr(f"Failed to stop picamera2 device: {exc}")
+                try:
+                    self._device.close()
+                except Exception as exc:
+                    self.logerr(f"Failed to close picamera2 device: {exc}")
+            else:
+                try:
+                    self._device.release()
+                except Exception as exc:
+                    self.logerr(f"Failed to release V4L2 device: {exc}")
             self.loginfo("Camera released.")
         self._device = None
+        self._use_picamera2 = False
 
 
 def main():


### PR DESCRIPTION
This pull request introduces support for the Raspberry Pi camera using the libcamera and picamera2 stack, addressing compatibility issues with the OV5647 sensor and improving camera handling on Ubuntu Noble. The camera driver now prefers picamera2 (libcamera) when available, with a fallback to V4L2 (OpenCV), and includes more robust image capture, rotation, and JPEG encoding logic. Several new dependencies are added to enable this functionality.

**Raspberry Pi camera and libcamera integration:**

* Added installation steps in the `Dockerfile` to build and install the Raspberry Pi fork of `libcamera` (v0.4.0) to resolve issues with the OV5647 sensor, and ensured Python bindings are properly exposed for import.
* Added all necessary build dependencies for libcamera and picamera2 to `dependencies-apt.txt`, including `git`, `meson`, `ninja-build`, and various development libraries.
* Added `picamera2==0.3.36` to `dependencies-py3.txt` to provide the Python API for the Raspberry Pi camera.

**Camera driver enhancements (`raspberry_pi_64.py`):**

* Refactored the camera node to prefer picamera2 (libcamera) for image capture, with fallback to V4L2 if unavailable. Added logic for image rotation, JPEG encoding, and robust error handling. The driver now properly configures camera controls and handles both camera APIs transparently.
* Improved resource cleanup and device release logic to handle both picamera2 and OpenCV devices safely.

These changes collectively make the camera driver more robust, compatible with newer Raspberry Pi camera stacks, and ready for Ubuntu Noble.