### PR TITLE
DTSW-8144-Reduce-Publish-Rate-for-ToF-sensors-not-being-used

### DIFF
--- a/packages/tof_driver/config/duckiedrone/front/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/front/default.yaml
@@ -1,6 +1,6 @@
 sensor_name: "front"
 sensor_model: "VL53L1X"
-frequency: 30
+frequency: 5  # Hz
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:

--- a/packages/tof_driver/config/duckiedrone/left/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/left/default.yaml
@@ -1,6 +1,6 @@
 sensor_name: "left"
 sensor_model: "VL53L1X"
-frequency: 30
+frequency: 5  # Hz
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:

--- a/packages/tof_driver/config/duckiedrone/right/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/right/default.yaml
@@ -1,6 +1,6 @@
 sensor_name: "right"
 sensor_model: "VL53L1X"
-frequency: 30
+frequency: 5  # Hz
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:

--- a/packages/tof_driver/config/duckiedrone/top/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/top/default.yaml
@@ -1,6 +1,6 @@
 sensor_name: "top"
 sensor_model: "VL53L1X"
-frequency: 30
+frequency: 5  # Hz
 mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:


### PR DESCRIPTION
Only the bottom ToF sensor is used for flight (it feeds height to EKF2). The front, left, right and top sensors run for the multi-ToF bring-up but do nothing during flight, and each one was still publishing at 30 Hz. Every sensor runs two processes (the driver here, plus its ROS2 bridge in dt-ros2-interface), so those four unused sensors were burning CPU on the Pi for no benefit.

Profiling on pdrone24 showed the cost is almost entirely per-message framework and transport work, not the sensor read itself, so dropping the publish rate cuts it nearly linearly. This lowers front/left/right/top to 5 Hz and leaves bottom at 30 Hz for EKF2.

Changes:
- `front`, `left`, `right`, `top` default configs: `frequency: 30 -> 5` (Hz)
- `bottom` left at 30 Hz on purpose

CPU measured live on pdrone24 (docker stats, 3-sample average, 100% = one core):

| Process | Before (30 Hz) | After (5 Hz) |
|---|--:|--:|
| driver-tof-front / left / right | 6.75 / 6.34 / 6.54 | 1.15 / 1.20 / 1.68 |
| ros2-tof-front / left / right | 5.51 / 5.41 / 5.35 | 0.99 / 1.08 / 1.06 |
| **Total (6 processes)** | **35.9** | **7.2** |

That is about 29 CPU points recovered, roughly 80% off those six processes, with no containers stopped.
