### PR TITLE
DTSW-8175-Update-DD24-B-3D-assembly-tool-and-related-assets

### DIFF
--- a/packages/tof_driver/config/duckiedrone/left/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/left/default.yaml
@@ -5,8 +5,8 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # left ToF -> port CHL1
-  -   bus: 24
+  # left ToF -> port CHL2
+  -   bus: 25
       address: 0x29
 
   # Raspberry Pi 5

--- a/packages/tof_driver/config/duckiedrone/right/default.yaml
+++ b/packages/tof_driver/config/duckiedrone/right/default.yaml
@@ -5,8 +5,8 @@ mode: "LONG_RANGE"
 display_fragment_frequency: 0
 connectors:
   # Raspberry Pi 4
-  # right ToF -> port CHL2
-  -   bus: 25
+  # right ToF -> port CHL1
+  -   bus: 24
       address: 0x29
 
   # Raspberry Pi 5


### PR DESCRIPTION
The left and right ToF sensor bus assignments didn't match the current CAD channel mapping. CAD now has left on CHL2 and right on CHL1, but the config had them swapped (left on CHL1/bus 24, right on CHL2/bus 25).

packages/tof_driver/config/duckiedrone/left/default.yaml: bus 24 (CHL1) → bus 25 (CHL2)
packages/tof_driver/config/duckiedrone/right/default.yaml: bus 25 (CHL2) → bus 24 (CHL1)
Bottom, top, and front were already correct against CAD, so no changes there.